### PR TITLE
Add desktop notification support for Heartbeat

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { getConfig, saveConfig, getDefaultHeartbeatConfig, BUILTIN_HEARTBEAT_TASKS } from '../core/config';
 import { mcpManager, type MCPConnectionStatus } from '../core/mcpManager';
+import { getNotificationPermission, requestNotificationPermission } from '../core/notifier';
 import type { AppConfig, MCPServerConfig, HeartbeatConfig, HeartbeatTask } from '../types';
 
 interface Props {
@@ -214,6 +215,38 @@ export function SettingsModal({ open, onClose }: Props) {
             </label>
           </div>
           <p className="mcp-hint">定期的にバックグラウンドチェックを実行し、変化があればチャットに通知します。</p>
+
+          {(() => {
+            const permission = getNotificationPermission();
+            return (
+              <div className="hb-notification-row">
+                <label className="mcp-toggle-label">
+                  <input
+                    type="checkbox"
+                    checked={heartbeat.desktopNotification}
+                    disabled={permission === 'denied' || permission === 'unsupported'}
+                    onChange={async (e) => {
+                      if (e.target.checked) {
+                        const result = await requestNotificationPermission();
+                        if (result === 'granted') {
+                          updateHeartbeat({ desktopNotification: true });
+                        }
+                      } else {
+                        updateHeartbeat({ desktopNotification: false });
+                      }
+                    }}
+                  />
+                  デスクトップ通知
+                </label>
+                {permission === 'denied' && (
+                  <p className="hb-notification-denied">通知がブロックされています。ブラウザの設定から許可してください。</p>
+                )}
+                {permission === 'unsupported' && (
+                  <p className="hb-notification-denied">このブラウザは通知をサポートしていません。</p>
+                )}
+              </div>
+            );
+          })()}
 
           <label className="hb-range-label">
             チェック間隔: {heartbeat.intervalMinutes}分

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -32,6 +32,7 @@ describe('getDefaultHeartbeatConfig', () => {
     expect(config.intervalMinutes).toBe(30);
     expect(config.quietHoursStart).toBe(0);
     expect(config.quietHoursEnd).toBe(6);
+    expect(config.desktopNotification).toBe(false);
     expect(config.tasks).toHaveLength(BUILTIN_HEARTBEAT_TASKS.length);
   });
 
@@ -79,6 +80,24 @@ describe('getConfig / saveConfig', () => {
     expect(config.braveApiKey).toBe('');
     expect(config.mcpServers).toEqual([]);
     expect(config.heartbeat).toEqual(getDefaultHeartbeatConfig());
+  });
+
+  it('既存の heartbeat に desktopNotification が無い場合デフォルト値でマージする', () => {
+    const oldHeartbeat = {
+      enabled: true,
+      intervalMinutes: 15,
+      quietHoursStart: 23,
+      quietHoursEnd: 7,
+      tasks: [],
+    };
+    localStorage.setItem('iagent-config', JSON.stringify({
+      openaiApiKey: 'sk-test',
+      heartbeat: oldHeartbeat,
+    }));
+    const config = getConfig();
+    expect(config.heartbeat!.enabled).toBe(true);
+    expect(config.heartbeat!.intervalMinutes).toBe(15);
+    expect(config.heartbeat!.desktopNotification).toBe(false);
   });
 });
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -26,6 +26,7 @@ export function getDefaultHeartbeatConfig(): HeartbeatConfig {
     quietHoursStart: 0,
     quietHoursEnd: 6,
     tasks: BUILTIN_HEARTBEAT_TASKS.map((t) => ({ ...t })),
+    desktopNotification: false,
   };
 }
 
@@ -40,7 +41,9 @@ export function getConfig(): AppConfig {
     braveApiKey: parsed.braveApiKey ?? '',
     openWeatherMapApiKey: parsed.openWeatherMapApiKey ?? '',
     mcpServers: parsed.mcpServers ?? [],
-    heartbeat: parsed.heartbeat ?? getDefaultHeartbeatConfig(),
+    heartbeat: parsed.heartbeat
+      ? { ...getDefaultHeartbeatConfig(), ...parsed.heartbeat }
+      : getDefaultHeartbeatConfig(),
   };
 }
 

--- a/src/core/notifier.test.ts
+++ b/src/core/notifier.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  isNotificationSupported,
+  getNotificationPermission,
+  requestNotificationPermission,
+  sendHeartbeatNotifications,
+} from './notifier';
+import type { HeartbeatResult } from '../types';
+
+describe('isNotificationSupported', () => {
+  const originalNotification = globalThis.Notification;
+
+  afterEach(() => {
+    if (originalNotification) {
+      Object.defineProperty(globalThis, 'Notification', {
+        value: originalNotification,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
+  it('Notification が存在すれば true', () => {
+    Object.defineProperty(globalThis, 'Notification', {
+      value: class MockNotification {
+        static permission = 'default';
+      },
+      writable: true,
+      configurable: true,
+    });
+    expect(isNotificationSupported()).toBe(true);
+  });
+
+  it('Notification が存在しなければ false', () => {
+    // @ts-expect-error テスト用に undefined に設定
+    delete globalThis.Notification;
+    expect(isNotificationSupported()).toBe(false);
+  });
+});
+
+describe('getNotificationPermission', () => {
+  const originalNotification = globalThis.Notification;
+
+  afterEach(() => {
+    if (originalNotification) {
+      Object.defineProperty(globalThis, 'Notification', {
+        value: originalNotification,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
+  it('Notification がなければ unsupported を返す', () => {
+    // @ts-expect-error テスト用に undefined に設定
+    delete globalThis.Notification;
+    expect(getNotificationPermission()).toBe('unsupported');
+  });
+
+  it('Notification.permission の値を返す', () => {
+    Object.defineProperty(globalThis, 'Notification', {
+      value: class MockNotification {
+        static permission = 'granted';
+      },
+      writable: true,
+      configurable: true,
+    });
+    expect(getNotificationPermission()).toBe('granted');
+  });
+});
+
+describe('requestNotificationPermission', () => {
+  const originalNotification = globalThis.Notification;
+
+  afterEach(() => {
+    if (originalNotification) {
+      Object.defineProperty(globalThis, 'Notification', {
+        value: originalNotification,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
+  it('Notification がなければ denied を返す', async () => {
+    // @ts-expect-error テスト用に undefined に設定
+    delete globalThis.Notification;
+    expect(await requestNotificationPermission()).toBe('denied');
+  });
+
+  it('requestPermission の結果を返す', async () => {
+    Object.defineProperty(globalThis, 'Notification', {
+      value: Object.assign(
+        class MockNotification {},
+        {
+          permission: 'default',
+          requestPermission: vi.fn().mockResolvedValue('granted'),
+        },
+      ),
+      writable: true,
+      configurable: true,
+    });
+    expect(await requestNotificationPermission()).toBe('granted');
+  });
+});
+
+describe('sendHeartbeatNotifications', () => {
+  const originalNotification = globalThis.Notification;
+  let mockInstances: Array<{ onclick: (() => void) | null; close: ReturnType<typeof vi.fn> }>;
+
+  beforeEach(() => {
+    mockInstances = [];
+    const MockNotification = vi.fn().mockImplementation(() => {
+      const instance = { onclick: null, close: vi.fn() };
+      mockInstances.push(instance);
+      return instance;
+    });
+    MockNotification.permission = 'granted';
+    MockNotification.requestPermission = vi.fn();
+
+    Object.defineProperty(globalThis, 'Notification', {
+      value: MockNotification,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    if (originalNotification) {
+      Object.defineProperty(globalThis, 'Notification', {
+        value: originalNotification,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
+  it('permission が granted のとき通知を作成する', () => {
+    const results: HeartbeatResult[] = [
+      { taskId: 'test-1', timestamp: 1000, hasChanges: true, summary: 'テスト通知' },
+    ];
+    sendHeartbeatNotifications(results);
+
+    expect(Notification).toHaveBeenCalledWith('iAgent Heartbeat', {
+      body: 'テスト通知',
+      tag: 'heartbeat-test-1-1000',
+    });
+  });
+
+  it('複数の結果に対して複数の通知を作成する', () => {
+    const results: HeartbeatResult[] = [
+      { taskId: 'test-1', timestamp: 1000, hasChanges: true, summary: '通知1' },
+      { taskId: 'test-2', timestamp: 1000, hasChanges: true, summary: '通知2' },
+    ];
+    sendHeartbeatNotifications(results);
+
+    expect(Notification).toHaveBeenCalledTimes(2);
+  });
+
+  it('permission が denied のとき通知を作成しない', () => {
+    Object.defineProperty(Notification, 'permission', { value: 'denied', configurable: true });
+    const results: HeartbeatResult[] = [
+      { taskId: 'test-1', timestamp: 1000, hasChanges: true, summary: 'テスト' },
+    ];
+    sendHeartbeatNotifications(results);
+
+    expect(mockInstances).toHaveLength(0);
+  });
+
+  it('onclick で window.focus を呼ぶ', () => {
+    const focusSpy = vi.spyOn(window, 'focus').mockImplementation(() => {});
+    const results: HeartbeatResult[] = [
+      { taskId: 'test-1', timestamp: 1000, hasChanges: true, summary: 'テスト' },
+    ];
+    sendHeartbeatNotifications(results);
+
+    expect(mockInstances).toHaveLength(1);
+    mockInstances[0].onclick?.();
+    expect(focusSpy).toHaveBeenCalled();
+    expect(mockInstances[0].close).toHaveBeenCalled();
+    focusSpy.mockRestore();
+  });
+});

--- a/src/core/notifier.ts
+++ b/src/core/notifier.ts
@@ -1,0 +1,34 @@
+import type { HeartbeatResult } from '../types';
+
+/** ブラウザが Notification API をサポートしているか */
+export function isNotificationSupported(): boolean {
+  return 'Notification' in window;
+}
+
+/** 現在の通知権限を返す */
+export function getNotificationPermission(): 'granted' | 'denied' | 'default' | 'unsupported' {
+  if (!isNotificationSupported()) return 'unsupported';
+  return Notification.permission;
+}
+
+/** 通知権限をリクエストする（ユーザーアクション起点で呼ぶこと） */
+export async function requestNotificationPermission(): Promise<'granted' | 'denied' | 'default'> {
+  if (!isNotificationSupported()) return 'denied';
+  return Notification.requestPermission();
+}
+
+/** Heartbeat 結果からデスクトップ通知を送信する */
+export function sendHeartbeatNotifications(results: HeartbeatResult[]): void {
+  if (getNotificationPermission() !== 'granted') return;
+
+  for (const result of results) {
+    const notification = new Notification('iAgent Heartbeat', {
+      body: result.summary,
+      tag: `heartbeat-${result.taskId}-${result.timestamp}`,
+    });
+    notification.onclick = () => {
+      window.focus();
+      notification.close();
+    };
+  }
+}

--- a/src/hooks/useHeartbeat.ts
+++ b/src/hooks/useHeartbeat.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import { HeartbeatEngine, type HeartbeatNotification } from '../core/heartbeat';
 import { getConfig } from '../core/config';
 import { mcpManager } from '../core/mcpManager';
+import { sendHeartbeatNotifications } from '../core/notifier';
 
 interface UseHeartbeatOptions {
   isStreaming: boolean;
@@ -18,6 +19,14 @@ export function useHeartbeat({ isStreaming, onNotification }: UseHeartbeatOption
 
     const unsub = engine.subscribe(onNotification);
 
+    // デスクトップ通知用リスナー
+    const unsubNotify = engine.subscribe((notification) => {
+      const cfg = getConfig().heartbeat;
+      if (cfg?.desktopNotification) {
+        sendHeartbeatNotifications(notification.results);
+      }
+    });
+
     const config = getConfig().heartbeat;
     if (config?.enabled) {
       engine.start();
@@ -25,6 +34,7 @@ export function useHeartbeat({ isStreaming, onNotification }: UseHeartbeatOption
 
     return () => {
       unsub();
+      unsubNotify();
       engine.stop();
       engineRef.current = null;
     };
@@ -44,7 +54,11 @@ export function useHeartbeat({ isStreaming, onNotification }: UseHeartbeatOption
       if (!engine) return;
 
       if (document.hidden) {
-        engine.stop();
+        // デスクトップ通知が有効ならバックグラウンドでも Heartbeat を継続
+        const config = getConfig().heartbeat;
+        if (!config?.desktopNotification) {
+          engine.stop();
+        }
       } else {
         const config = getConfig().heartbeat;
         if (config?.enabled) {

--- a/src/index.css
+++ b/src/index.css
@@ -745,6 +745,19 @@ body {
   border-color: var(--accent);
 }
 
+/* Heartbeat notification settings */
+.hb-notification-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.hb-notification-denied {
+  font-size: 11px;
+  color: #f87171;
+  line-height: 1.3;
+}
+
 /* Heartbeat message badge */
 .message-heartbeat .message-bubble {
   border-left: 3px solid #4ade80;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,6 +58,7 @@ export interface HeartbeatConfig {
   quietHoursStart: number;
   quietHoursEnd: number;
   tasks: HeartbeatTask[];
+  desktopNotification: boolean;
 }
 
 export interface AppConfig {


### PR DESCRIPTION
## Summary
- Heartbeat の結果をブラウザの Notification API でデスクトップ通知として送信する機能を追加
- 設定画面にトグルを追加し、ユーザーアクション起点で通知権限をリクエスト
- デスクトップ通知が有効な場合、タブがバックグラウンドでも Heartbeat を停止せず継続

## Test plan
- [x] `npm test` — 全43テスト通過
- [x] `npm run build` — ビルド成功
- [ ] 設定画面で「デスクトップ通知」トグル ON → 権限ダイアログ表示を確認
- [ ] Heartbeat 実行時にデスクトップ通知が表示されることを確認
- [ ] 通知クリックでアプリにフォーカスが戻ることを確認
- [ ] 通知ブロック時に警告テキストが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)