### PR TITLE
Add agent long-term memory

### DIFF
--- a/src/core/agent.test.ts
+++ b/src/core/agent.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { __resetStores } from '../store/__mocks__/db';
+
+vi.mock('../store/db');
+
+import { createAgent, createHeartbeatAgent } from './agent';
+import { saveMemory } from '../store/memoryStore';
+
+// Agent クラスをモックして instructions とツールを検証可能にする
+vi.mock('@openai/agents', () => {
+  return {
+    Agent: class MockAgent {
+      name: string;
+      instructions: string;
+      tools: unknown[];
+      constructor(opts: { name: string; instructions: string; tools: unknown[] }) {
+        this.name = opts.name;
+        this.instructions = opts.instructions;
+        this.tools = opts.tools;
+      }
+    },
+    tool: vi.fn((opts) => ({ ...opts, __isTool: true })),
+  };
+});
+
+vi.mock('../tools/calendarTool', () => ({
+  calendarTool: { name: 'calendar', __isTool: true },
+}));
+
+vi.mock('../tools/webSearchTool', () => ({
+  webSearchTool: { name: 'webSearch', __isTool: true },
+}));
+
+vi.mock('../tools/deviceInfoTool', () => ({
+  deviceInfoTool: { name: 'deviceInfo', __isTool: true },
+}));
+
+vi.mock('../tools/memoryTool', () => ({
+  memoryTool: { name: 'memory', __isTool: true },
+}));
+
+beforeEach(() => {
+  __resetStores();
+});
+
+describe('createAgent', () => {
+  it('メモリ0件の時、instructions に「あなたの記憶」が含まれない', async () => {
+    const agent = await createAgent() as unknown as { instructions: string };
+    expect(agent.instructions).not.toContain('あなたの記憶');
+  });
+
+  it('メモリありの時、instructions にメモリ内容が含まれる', async () => {
+    await saveMemory('ユーザーは東京在住', 'fact');
+    await saveMemory('朝にニュースを確認したい', 'preference');
+
+    const agent = await createAgent() as unknown as { instructions: string };
+    expect(agent.instructions).toContain('あなたの記憶');
+    expect(agent.instructions).toContain('[fact] ユーザーは東京在住');
+    expect(agent.instructions).toContain('[preference] 朝にニュースを確認したい');
+  });
+
+  it('memoryTool をツール一覧に含む', async () => {
+    const agent = await createAgent() as unknown as { tools: Array<{ name: string }> };
+    const toolNames = agent.tools.map((t) => t.name);
+    expect(toolNames).toContain('memory');
+  });
+
+  it('メモリについての指示が instructions に含まれる', async () => {
+    const agent = await createAgent() as unknown as { instructions: string };
+    expect(agent.instructions).toContain('メモリについて');
+    expect(agent.instructions).toContain('memory ツールの save アクション');
+  });
+});
+
+describe('createHeartbeatAgent', () => {
+  it('メモリ0件の時、instructions に記憶セクションが含まれない', async () => {
+    const agent = await createHeartbeatAgent() as unknown as { instructions: string };
+    expect(agent.instructions).not.toContain('ユーザーについての記憶');
+  });
+
+  it('メモリありの時、instructions にメモリ内容が含まれる', async () => {
+    await saveMemory('ユーザーは東京在住', 'fact');
+
+    const agent = await createHeartbeatAgent() as unknown as { instructions: string };
+    expect(agent.instructions).toContain('ユーザーについての記憶');
+    expect(agent.instructions).toContain('[fact] ユーザーは東京在住');
+  });
+});

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -3,22 +3,41 @@ import type { MCPServer } from '@openai/agents';
 import { calendarTool } from '../tools/calendarTool';
 import { webSearchTool } from '../tools/webSearchTool';
 import { deviceInfoTool } from '../tools/deviceInfoTool';
+import { memoryTool } from '../tools/memoryTool';
+import { getRecentMemories } from '../store/memoryStore';
 
-export const createAgent = (mcpServers?: MCPServer[]) => new Agent({
-  name: 'iAgent',
-  instructions: `あなたはiAgentです。ブラウザ上で動作するパーソナルAIアシスタントです。
+export async function createAgent(mcpServers?: MCPServer[]): Promise<Agent> {
+  const memories = await getRecentMemories(10);
+  const memoryContext = memories.length > 0
+    ? `\n\n## あなたの記憶\n以下はこれまでに保存した重要な情報です:\n${memories.map((m) => `- [${m.category}] ${m.content}`).join('\n')}`
+    : '';
+
+  return new Agent({
+    name: 'iAgent',
+    instructions: `あなたはiAgentです。ブラウザ上で動作するパーソナルAIアシスタントです。
 ユーザーの質問に答え、必要に応じてツールを使用してタスクを実行します。
 ツールの結果を受け取ったら、ユーザーにわかりやすく日本語で説明してください。
 日付や時刻に関する操作では、ユーザーのローカルタイムゾーンを考慮してください。
-現在の日時: ${new Date().toLocaleString('ja-JP')}`,
-  model: 'gpt-5-mini',
-  tools: [calendarTool, webSearchTool, deviceInfoTool],
-  mcpServers: mcpServers && mcpServers.length > 0 ? mcpServers : undefined,
-});
+現在の日時: ${new Date().toLocaleString('ja-JP')}
 
-export const createHeartbeatAgent = (mcpServers?: MCPServer[]) => new Agent({
-  name: 'iAgent-Heartbeat',
-  instructions: `あなたはiAgentのバックグラウンドチェッカーです。
+## メモリについて
+ユーザーとの会話で重要な情報（好み、事実、文脈）を発見したら、memory ツールの save アクションで保存してください。
+既に保存済みの情報を更新する場合は、古いメモリを delete してから新しい内容で save してください。${memoryContext}`,
+    model: 'gpt-5-mini',
+    tools: [calendarTool, webSearchTool, deviceInfoTool, memoryTool],
+    mcpServers: mcpServers && mcpServers.length > 0 ? mcpServers : undefined,
+  });
+}
+
+export async function createHeartbeatAgent(mcpServers?: MCPServer[]): Promise<Agent> {
+  const memories = await getRecentMemories(5);
+  const memoryContext = memories.length > 0
+    ? `\n\nユーザーについての記憶:\n${memories.map((m) => `- [${m.category}] ${m.content}`).join('\n')}`
+    : '';
+
+  return new Agent({
+    name: 'iAgent-Heartbeat',
+    instructions: `あなたはiAgentのバックグラウンドチェッカーです。
 与えられたタスクに基づいて定期チェックを実行し、結果をJSON形式で返してください。
 
 必ず以下のJSON形式で回答してください（他のテキストは含めないでください）:
@@ -36,8 +55,9 @@ export const createHeartbeatAgent = (mcpServers?: MCPServer[]) => new Agent({
 ルール:
 - hasChanges が false の場合、summary は空文字列にしてください
 - 通知する価値がある情報のみ hasChanges: true にしてください
-- 日本語で summary を書いてください`,
-  model: 'gpt-5-nano',
-  tools: [calendarTool, deviceInfoTool],
-  mcpServers: mcpServers && mcpServers.length > 0 ? mcpServers : undefined,
-});
+- 日本語で summary を書いてください${memoryContext}`,
+    model: 'gpt-5-nano',
+    tools: [calendarTool, deviceInfoTool],
+    mcpServers: mcpServers && mcpServers.length > 0 ? mcpServers : undefined,
+  });
+}

--- a/src/core/heartbeat.ts
+++ b/src/core/heartbeat.ts
@@ -105,7 +105,7 @@ export class HeartbeatEngine {
       setDefaultOpenAIClient(client);
 
       const mcpServers = this.getMCPServers();
-      const agent = createHeartbeatAgent(mcpServers);
+      const agent = await createHeartbeatAgent(mcpServers);
 
       const taskDescriptions = tasks.map((t) =>
         `- タスクID: ${t.id}, タスク名: ${t.name}, 内容: ${t.description}`

--- a/src/hooks/useAgentChat.ts
+++ b/src/hooks/useAgentChat.ts
@@ -60,7 +60,7 @@ export function useAgentChat(initialMessages: ChatMessage[] = []) {
 
     try {
       const mcpServers = mcpManager.getActiveServers();
-      const agent = createAgent(mcpServers);
+      const agent = await createAgent(mcpServers);
       historyRef.current.push(user(text));
 
       const result = await run(agent, historyRef.current, {

--- a/src/store/__mocks__/db.ts
+++ b/src/store/__mocks__/db.ts
@@ -40,8 +40,18 @@ const mockDB = {
     getStore(storeName).delete(key);
     return Promise.resolve();
   },
-  getAllFromIndex(storeName: string, _indexName: string) {
-    return Promise.resolve([...getStore(storeName).values()].map((v) => structuredClone(v)));
+  getAllKeys(storeName: string) {
+    return Promise.resolve([...getStore(storeName).keys()]);
+  },
+  getAllFromIndex(storeName: string, _indexName: string, query?: string | number) {
+    const store = getStore(storeName);
+    if (query !== undefined) {
+      const filtered = [...store.values()].filter((v) => {
+        return Object.values(v as Record<string, unknown>).includes(query);
+      });
+      return Promise.resolve(filtered.map((v) => structuredClone(v)));
+    }
+    return Promise.resolve([...store.values()].map((v) => structuredClone(v)));
   },
 };
 

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -1,7 +1,7 @@
 import { openDB, type IDBPDatabase } from 'idb';
 
 const DB_NAME = 'iagent-db';
-const DB_VERSION = 3;
+const DB_VERSION = 4;
 
 let dbPromise: Promise<IDBPDatabase> | null = null;
 
@@ -18,6 +18,11 @@ export function getDB(): Promise<IDBPDatabase> {
         }
         if (!db.objectStoreNames.contains('heartbeat')) {
           db.createObjectStore('heartbeat', { keyPath: 'key' });
+        }
+        if (!db.objectStoreNames.contains('memories')) {
+          const memStore = db.createObjectStore('memories', { keyPath: 'id' });
+          memStore.createIndex('category', 'category', { unique: false });
+          memStore.createIndex('updatedAt', 'updatedAt', { unique: false });
         }
       },
       blocked() {

--- a/src/store/memoryStore.test.ts
+++ b/src/store/memoryStore.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { __resetStores } from './__mocks__/db';
+
+vi.mock('./db');
+
+import {
+  saveMemory,
+  searchMemories,
+  listMemories,
+  deleteMemory,
+  getRecentMemories,
+} from './memoryStore';
+
+beforeEach(() => {
+  __resetStores();
+});
+
+describe('saveMemory', () => {
+  it('メモリを保存して返却値を検証する', async () => {
+    const memory = await saveMemory('ユーザーは東京在住', 'fact');
+    expect(memory.id).toBeDefined();
+    expect(memory.content).toBe('ユーザーは東京在住');
+    expect(memory.category).toBe('fact');
+    expect(memory.createdAt).toBeGreaterThan(0);
+    expect(memory.updatedAt).toBe(memory.createdAt);
+  });
+
+  it('MAX_MEMORIES を超えたとき最古が削除される', async () => {
+    // 100件保存
+    for (let i = 0; i < 100; i++) {
+      const m = await saveMemory(`メモリ ${i}`, 'other');
+      // updatedAt を手動で設定して順序を保証
+      const db = (await import('./__mocks__/db')).getDB;
+      const mockDb = await db();
+      const stored = await mockDb.get('memories', m.id);
+      if (stored) {
+        stored.updatedAt = i;
+        await mockDb.put('memories', stored);
+      }
+    }
+
+    const before = await listMemories();
+    expect(before).toHaveLength(100);
+
+    // 101件目を保存 → 最古が削除される
+    await saveMemory('新しいメモリ', 'other');
+    const after = await listMemories();
+    expect(after).toHaveLength(100);
+    expect(after.find((m) => m.content === '新しいメモリ')).toBeDefined();
+  });
+});
+
+describe('searchMemories', () => {
+  it('キーワードに一致するメモリのみ返す', async () => {
+    await saveMemory('ユーザーは東京在住', 'fact');
+    await saveMemory('朝にニュースを確認したい', 'preference');
+    await saveMemory('プロジェクトXの締切は3月末', 'context');
+
+    const results = await searchMemories('東京');
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe('ユーザーは東京在住');
+  });
+
+  it('大文字小文字を区別しない', async () => {
+    await saveMemory('React is preferred', 'preference');
+    await saveMemory('Vue is also used', 'preference');
+
+    const results = await searchMemories('react');
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe('React is preferred');
+  });
+});
+
+describe('listMemories', () => {
+  it('全件取得し updatedAt 降順で返す', async () => {
+    const m1 = await saveMemory('メモリ1', 'fact');
+    const m2 = await saveMemory('メモリ2', 'preference');
+    const m3 = await saveMemory('メモリ3', 'context');
+
+    // updatedAt を手動設定
+    const { getDB: db } = await import('./__mocks__/db');
+    const mockDb = await db();
+    const s1 = await mockDb.get('memories', m1.id);
+    const s2 = await mockDb.get('memories', m2.id);
+    const s3 = await mockDb.get('memories', m3.id);
+    s1!.updatedAt = 1000;
+    s2!.updatedAt = 3000;
+    s3!.updatedAt = 2000;
+    await mockDb.put('memories', s1!);
+    await mockDb.put('memories', s2!);
+    await mockDb.put('memories', s3!);
+
+    const all = await listMemories();
+    expect(all).toHaveLength(3);
+    expect(all[0].content).toBe('メモリ2');
+    expect(all[1].content).toBe('メモリ3');
+    expect(all[2].content).toBe('メモリ1');
+  });
+
+  it('カテゴリ指定で絞り込みできる', async () => {
+    await saveMemory('好みA', 'preference');
+    await saveMemory('事実B', 'fact');
+    await saveMemory('好みC', 'preference');
+
+    const prefs = await listMemories('preference');
+    expect(prefs).toHaveLength(2);
+    prefs.forEach((m) => expect(m.category).toBe('preference'));
+  });
+});
+
+describe('deleteMemory', () => {
+  it('存在するメモリを削除できる', async () => {
+    const memory = await saveMemory('削除対象', 'other');
+    const result = await deleteMemory(memory.id);
+    expect(result).toBe(true);
+
+    const all = await listMemories();
+    expect(all).toHaveLength(0);
+  });
+
+  it('存在しないIDで false を返す', async () => {
+    const result = await deleteMemory('non-existent-id');
+    expect(result).toBe(false);
+  });
+});
+
+describe('getRecentMemories', () => {
+  it('limit 件数の制限が効く', async () => {
+    for (let i = 0; i < 5; i++) {
+      await saveMemory(`メモリ ${i}`, 'other');
+    }
+
+    const recent = await getRecentMemories(3);
+    expect(recent).toHaveLength(3);
+  });
+
+  it('デフォルトで最大10件返す', async () => {
+    for (let i = 0; i < 15; i++) {
+      await saveMemory(`メモリ ${i}`, 'other');
+    }
+
+    const recent = await getRecentMemories();
+    expect(recent).toHaveLength(10);
+  });
+});

--- a/src/store/memoryStore.ts
+++ b/src/store/memoryStore.ts
@@ -1,0 +1,57 @@
+import { getDB } from './db';
+import type { Memory } from '../types';
+
+const STORE_NAME = 'memories';
+const MAX_MEMORIES = 100;
+
+export async function saveMemory(content: string, category: Memory['category']): Promise<Memory> {
+  const db = await getDB();
+  const now = Date.now();
+  const memory: Memory = {
+    id: crypto.randomUUID(),
+    content,
+    category,
+    createdAt: now,
+    updatedAt: now,
+  };
+  // 上限チェック: 古いものから削除
+  const all = await db.getAll(STORE_NAME);
+  if (all.length >= MAX_MEMORIES) {
+    const oldest = [...all].sort((a, b) => a.updatedAt - b.updatedAt)[0];
+    await db.delete(STORE_NAME, oldest.id);
+  }
+  await db.put(STORE_NAME, memory);
+  return memory;
+}
+
+export async function searchMemories(query: string): Promise<Memory[]> {
+  const db = await getDB();
+  const all: Memory[] = await db.getAll(STORE_NAME);
+  const lowerQuery = query.toLowerCase();
+  return all
+    .filter((m) => m.content.toLowerCase().includes(lowerQuery))
+    .sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+export async function listMemories(category?: Memory['category']): Promise<Memory[]> {
+  const db = await getDB();
+  if (category) {
+    const results: Memory[] = await db.getAllFromIndex(STORE_NAME, 'category', category);
+    return results.sort((a, b) => b.updatedAt - a.updatedAt);
+  }
+  const all: Memory[] = await db.getAll(STORE_NAME);
+  return all.sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+export async function deleteMemory(id: string): Promise<boolean> {
+  const db = await getDB();
+  const existing = await db.get(STORE_NAME, id);
+  if (!existing) return false;
+  await db.delete(STORE_NAME, id);
+  return true;
+}
+
+export async function getRecentMemories(limit: number = 10): Promise<Memory[]> {
+  const all = await listMemories();
+  return all.slice(0, limit);
+}

--- a/src/tools/memoryTool.ts
+++ b/src/tools/memoryTool.ts
@@ -1,0 +1,54 @@
+import { tool } from '@openai/agents';
+import { z } from 'zod';
+import { saveMemory, searchMemories, listMemories, deleteMemory } from '../store/memoryStore';
+
+export const memoryTool = tool({
+  name: 'memory',
+  description: `長期メモリを管理します。ユーザーの好み・重要な情報・文脈を保存し、後から参照できます。
+action:
+- "save": メモリを保存。content（内容）と category（preference/fact/context/other）を指定。
+- "search": キーワードでメモリを検索。query を指定。
+- "list": メモリ一覧を取得。category で絞り込み可能（空文字で全件）。
+- "delete": メモリを削除。id を指定。`,
+  parameters: z.object({
+    action: z.enum(['save', 'search', 'list', 'delete']),
+    content: z.string().describe('保存するメモリの内容。save 時に必須、他は空文字'),
+    category: z.string().describe('カテゴリ（preference/fact/context/other）。save 時に必須、list 時はフィルタ用、他は空文字'),
+    query: z.string().describe('検索キーワード。search 時に必須、他は空文字'),
+    id: z.string().describe('削除対象のメモリID。delete 時に必須、他は空文字'),
+  }),
+  execute: async ({ action, content, category, query, id }) => {
+    if (action === 'save') {
+      if (!content) return JSON.stringify({ error: 'content は必須です' });
+      const validCategories = ['preference', 'fact', 'context', 'other'] as const;
+      const cat = validCategories.includes(category as typeof validCategories[number])
+        ? (category as typeof validCategories[number])
+        : 'other';
+      const memory = await saveMemory(content, cat);
+      return JSON.stringify({ message: 'メモリを保存しました', memory });
+    }
+
+    if (action === 'search') {
+      if (!query) return JSON.stringify({ error: 'query は必須です' });
+      const results = await searchMemories(query);
+      return JSON.stringify({ results, count: results.length });
+    }
+
+    if (action === 'list') {
+      const validCategories = ['preference', 'fact', 'context', 'other'] as const;
+      const cat = validCategories.includes(category as typeof validCategories[number])
+        ? (category as typeof validCategories[number])
+        : undefined;
+      const memories = await listMemories(cat);
+      return JSON.stringify({ memories, count: memories.length });
+    }
+
+    if (action === 'delete') {
+      if (!id) return JSON.stringify({ error: 'id は必須です' });
+      const deleted = await deleteMemory(id);
+      return JSON.stringify({ message: deleted ? '削除しました' : 'メモリが見つかりません' });
+    }
+
+    return JSON.stringify({ error: '不明なアクションです' });
+  },
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,5 +69,13 @@ export interface AppConfig {
   heartbeat?: HeartbeatConfig;
 }
 
+export interface Memory {
+  id: string;
+  content: string;
+  category: 'preference' | 'fact' | 'context' | 'other';
+  createdAt: number;
+  updatedAt: number;
+}
+
 /** getConfigValue() で文字列として取得可能なキー */
 export type ConfigKey = 'openaiApiKey' | 'braveApiKey' | 'openWeatherMapApiKey';


### PR DESCRIPTION
## Summary
- IndexedDB に `memories` ストアを追加し、エージェントがユーザーの好み・事実・文脈を会話を跨いで記憶できるように
- `memoryTool`（save/search/list/delete）をエージェントのツール一覧に追加
- エージェント作成時に最新メモリ（最大10件）を instructions に自動注入し、パーソナライズされた応答を実現
- Heartbeat エージェントもメモリ参照可能（最大5件、読み取り専用）

## Test plan
- [x] `npm test` — 全59テスト通過（memoryStore: 10件、agent: 6件を含む）
- [x] `npm run build` — ビルド成功
- [ ] `npm run dev` → チャットで「私の名前は太郎です、覚えておいて」→ memory ツールで保存されることを確認
- [ ] ページリロード → 「私の名前を知っていますか？」→ メモリから情報を引き出して回答することを確認
- [ ] 「保存したメモリを一覧表示して」→ memory ツールの list が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)