### PR TITLE
Add test infrastructure for 4 modules (Statements 53% → 86%)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,7 +19,7 @@
 - カスタムワークフロー（タスクごとの個別スケジュール設定）
 - オブザーバビリティ基盤（OTel 互換トレーサー + OTLP/HTTP エクスポーター）
 - 会話履歴の複数管理（サイドバー + 作成・切替・削除）
-- テスト 126 件
+- テスト 173 件（Statements 86.45%）
 
 ---
 
@@ -40,12 +40,34 @@
 - [x] Heartbeat 計装（タスク実行トレース）
 - [x] 設定 UI（有効/無効、OTLP エンドポイント、認証ヘッダー）
 
-### テストカバレッジ向上
-- [ ] `calendarStore.ts` のテスト追加（現 7.69%）
-- [ ] `mcpClient.ts` のテスト追加（現 0%）
-- [ ] `mcpManager.ts` のテスト追加（現 0%）
-- [ ] `heartbeat.ts` のカバレッジ改善（現 47.36%）
-- **目標**: Statements 70% 以上
+### テスト基盤の拡充
+
+#### ユニットテスト完備（Statements 70% 目標 → 達成済み 86.45%）
+- [x] `calendarStore.ts` のテスト追加（7.69% → 100%）
+- [x] `mcpClient.ts` のテスト追加（0% → 98.76%）
+- [x] `mcpManager.ts` のテスト追加（0% → 98.82%）
+- [x] `heartbeat.ts` のカバレッジ改善（51.53% → 96.31%）
+- [ ] CI にカバレッジ閾値（Statements 70%）を設定
+
+#### コンポーネント / フックテスト導入
+- [ ] @testing-library/react + @testing-library/user-event 導入
+- [ ] InputBar テスト（入力 → 送信、空文字無効化、ストリーミング中ブロック）
+- [ ] SettingsModal テスト（API キー入力保存、MCP サーバー追加削除）
+- [ ] ConversationSidebar テスト（一覧表示、選択、削除）
+- [ ] useConversations フックテスト（CRUD、マイグレーション）
+- [ ] useHeartbeat フックテスト（エンジン連携、visibility 連動）
+
+#### E2E テスト導入
+- [ ] Playwright 導入 + page.route() で OpenAI API モック
+- [ ] 初回起動 → API キー設定 → チャット送信フロー
+- [ ] 会話管理（作成・切替・削除）フロー
+- [ ] モバイルビューポートでのドロワー動作
+- [ ] CI に E2E テストステップ追加（main PR 時のみ）
+
+#### テスト品質の継続改善
+- [ ] telemetry をカバレッジ対象に追加
+- [ ] ツール定義（calendarTool 等）のインテグレーションテスト
+- [ ] Visual Regression テスト（Playwright スクリーンショット比較）
 
 ---
 
@@ -108,3 +130,4 @@
 - [x] カスタムワークフロー — タスクごとの個別スケジュール（global/interval/fixed-time）（2026-02-24）
 - [x] オブザーバビリティ基盤 — OTel 互換トレーサー + IndexedDB 永続化 + OTLP/HTTP エクスポーター（2026-02-25）
 - [x] 会話履歴の複数管理 — サイドバー UI + 作成・切替・削除 + 既存データマイグレーション（2026-02-25）
+- [x] テスト基盤拡充 — calendarStore/mcpClient/mcpManager/heartbeat テスト追加、Statements 53.4% → 86.45%（2026-02-25）

--- a/src/core/heartbeat.test.ts
+++ b/src/core/heartbeat.test.ts
@@ -235,3 +235,535 @@ describe('getTasksDue', () => {
     expect(due).toHaveLength(0);
   });
 });
+
+// --- executeCheck / tick / runNow テスト ---
+// vi.doMock + vi.resetModules + 動的 import で各テストに独立したモック環境を構築
+
+describe('HeartbeatEngine - executeCheck', () => {
+  const testTask: HeartbeatTask = {
+    id: 'test-task',
+    name: 'テストタスク',
+    description: 'テスト用タスク',
+    enabled: true,
+    type: 'custom',
+  };
+
+  const heartbeatConfig: HeartbeatConfig = {
+    enabled: true,
+    intervalMinutes: 1,
+    quietHoursStart: 0,
+    quietHoursEnd: 0,
+    tasks: [testTask],
+    desktopNotification: false,
+  };
+
+  let mockRun: ReturnType<typeof vi.fn>;
+  let mockAddEvent: ReturnType<typeof vi.fn>;
+  let mockEndWithError: ReturnType<typeof vi.fn>;
+  let mockAddHeartbeatResult: ReturnType<typeof vi.fn>;
+  let mockUpdateLastCheckedFn: ReturnType<typeof vi.fn>;
+  let mockUpdateTaskLastRunFn: ReturnType<typeof vi.fn>;
+
+  function setupMocks(configOverrides?: Partial<{ openaiApiKey: string; heartbeat: HeartbeatConfig }>) {
+    mockRun = vi.fn();
+    mockAddEvent = vi.fn();
+    mockEndWithError = vi.fn();
+    mockAddHeartbeatResult = vi.fn().mockResolvedValue(undefined);
+    mockUpdateLastCheckedFn = vi.fn().mockResolvedValue(undefined);
+    mockUpdateTaskLastRunFn = vi.fn().mockResolvedValue(undefined);
+
+    vi.resetModules();
+
+    vi.doMock('../store/db', async () => {
+      return await import('../store/__mocks__/db');
+    });
+
+    vi.doMock('./config', () => ({
+      getConfig: vi.fn().mockReturnValue({
+        openaiApiKey: configOverrides?.openaiApiKey ?? 'sk-test-key',
+        braveApiKey: '',
+        openWeatherMapApiKey: '',
+        mcpServers: [],
+        heartbeat: configOverrides?.heartbeat ?? heartbeatConfig,
+      }),
+    }));
+
+    vi.doMock('../telemetry/tracer', () => ({
+      tracer: {
+        startTrace: vi.fn().mockReturnValue({
+          rootSpan: {
+            setAttribute: vi.fn(),
+            addEvent: mockAddEvent,
+            endWithError: mockEndWithError,
+          },
+          finish: vi.fn().mockResolvedValue(undefined),
+        }),
+      },
+    }));
+
+    vi.doMock('../telemetry/semantics', () => ({
+      LLM_ATTRS: { SYSTEM: 'gen_ai.system', MODEL: 'gen_ai.request.model' },
+      HEARTBEAT_ATTRS: { TASK_COUNT: 'heartbeat.task.count', TASK_ID: 'heartbeat.task.id', HAS_CHANGES: 'heartbeat.has_changes' },
+    }));
+
+    vi.doMock('@openai/agents', () => ({
+      run: mockRun,
+      user: (msg: string) => ({ role: 'user', content: msg }),
+    }));
+
+    vi.doMock('@openai/agents-openai', () => ({
+      setDefaultOpenAIClient: vi.fn(),
+    }));
+
+    vi.doMock('openai', () => ({
+      default: vi.fn().mockImplementation(() => ({})),
+    }));
+
+    vi.doMock('./agent', () => ({
+      createHeartbeatAgent: vi.fn().mockResolvedValue({ name: 'mock-agent' }),
+    }));
+
+    vi.doMock('../store/heartbeatStore', () => ({
+      loadHeartbeatState: vi.fn().mockResolvedValue({ lastChecked: 0, recentResults: [] }),
+      addHeartbeatResult: mockAddHeartbeatResult,
+      updateLastChecked: mockUpdateLastCheckedFn,
+      updateTaskLastRun: mockUpdateTaskLastRunFn,
+      getTaskLastRun: vi.fn().mockResolvedValue(0),
+    }));
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers({ now: new Date(2025, 0, 1, 12, 0, 0) });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('API キー未設定でスキップする', async () => {
+    setupMocks({ openaiApiKey: '' });
+
+    const { HeartbeatEngine: FreshEngine } = await import('./heartbeat');
+    const engine = new FreshEngine(() => []);
+    engine.start();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(mockRun).not.toHaveBeenCalled();
+    expect(mockAddEvent).toHaveBeenCalledWith('heartbeat.skip', { reason: 'no_api_key' });
+
+    engine.stop();
+  });
+
+  it('Agent 実行成功 + hasChanges=true でリスナー通知する', async () => {
+    setupMocks();
+    mockRun.mockResolvedValue({
+      finalOutput: JSON.stringify({
+        results: [{ taskId: 'test-task', hasChanges: true, summary: '変更あり' }],
+      }),
+    });
+
+    const { HeartbeatEngine: FreshEngine } = await import('./heartbeat');
+    const engine = new FreshEngine(() => []);
+    const listener = vi.fn();
+    engine.subscribe(listener);
+    engine.start();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(mockRun).toHaveBeenCalled();
+    expect(mockAddHeartbeatResult).toHaveBeenCalled();
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        results: expect.arrayContaining([
+          expect.objectContaining({ taskId: 'test-task', hasChanges: true }),
+        ]),
+      }),
+    );
+
+    engine.stop();
+  });
+
+  it('Agent 実行成功 + hasChanges=false で通知しない', async () => {
+    setupMocks();
+    mockRun.mockResolvedValue({
+      finalOutput: JSON.stringify({
+        results: [{ taskId: 'test-task', hasChanges: false, summary: '' }],
+      }),
+    });
+
+    const { HeartbeatEngine: FreshEngine } = await import('./heartbeat');
+    const engine = new FreshEngine(() => []);
+    const listener = vi.fn();
+    engine.subscribe(listener);
+    engine.start();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(mockRun).toHaveBeenCalled();
+    expect(listener).not.toHaveBeenCalled();
+
+    engine.stop();
+  });
+
+  it('finalOutput が string でない場合スキップする', async () => {
+    setupMocks();
+    mockRun.mockResolvedValue({ finalOutput: 42 });
+
+    const { HeartbeatEngine: FreshEngine } = await import('./heartbeat');
+    const engine = new FreshEngine(() => []);
+    engine.start();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(mockAddEvent).toHaveBeenCalledWith('heartbeat.skip', { reason: 'no_string_output' });
+    expect(mockAddHeartbeatResult).not.toHaveBeenCalled();
+
+    engine.stop();
+  });
+
+  it('JSON パース失敗時にエラーハンドリングする', async () => {
+    setupMocks();
+    mockRun.mockResolvedValue({ finalOutput: 'not json at all' });
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { HeartbeatEngine: FreshEngine } = await import('./heartbeat');
+    const engine = new FreshEngine(() => []);
+    engine.start();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // JSON にマッチしない → no_json_match でスキップ
+    expect(mockAddEvent).toHaveBeenCalledWith('heartbeat.skip', { reason: 'no_json_match' });
+
+    engine.stop();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('Agent 実行エラーで lastChecked を更新する（無限リトライ防止）', async () => {
+    setupMocks();
+    mockRun.mockRejectedValue(new Error('API エラー'));
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { HeartbeatEngine: FreshEngine } = await import('./heartbeat');
+    const engine = new FreshEngine(() => []);
+    engine.start();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(mockEndWithError).toHaveBeenCalled();
+    expect(mockUpdateLastCheckedFn).toHaveBeenCalled();
+
+    engine.stop();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('結果を heartbeatStore に保存する', async () => {
+    setupMocks();
+    mockRun.mockResolvedValue({
+      finalOutput: JSON.stringify({
+        results: [{ taskId: 'test-task', hasChanges: true, summary: 'テスト結果' }],
+      }),
+    });
+
+    const { HeartbeatEngine: FreshEngine } = await import('./heartbeat');
+    const engine = new FreshEngine(() => []);
+    engine.start();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(mockAddHeartbeatResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: 'test-task',
+        hasChanges: true,
+        summary: 'テスト結果',
+      }),
+    );
+    expect(mockUpdateTaskLastRunFn).toHaveBeenCalledWith('test-task', expect.any(Number));
+
+    engine.stop();
+  });
+});
+
+describe('HeartbeatEngine - tick', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: new Date(2025, 0, 1, 12, 0, 0) });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('isExecuting=true でスキップする', async () => {
+    const mockRunSlow = vi.fn();
+    mockRunSlow.mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve({ finalOutput: '{}' }), 120_000)));
+
+    vi.resetModules();
+    vi.doMock('../store/db', async () => await import('../store/__mocks__/db'));
+    vi.doMock('./config', () => ({
+      getConfig: vi.fn().mockReturnValue({
+        openaiApiKey: 'sk-test',
+        heartbeat: {
+          enabled: true, intervalMinutes: 1,
+          quietHoursStart: 0, quietHoursEnd: 0,
+          tasks: [{ id: 't', name: 't', description: 't', enabled: true, type: 'custom' as const }],
+          desktopNotification: false,
+        },
+      }),
+    }));
+    vi.doMock('@openai/agents', () => ({ run: mockRunSlow, user: (msg: string) => ({ role: 'user', content: msg }) }));
+    vi.doMock('@openai/agents-openai', () => ({ setDefaultOpenAIClient: vi.fn() }));
+    vi.doMock('openai', () => ({ default: vi.fn().mockImplementation(() => ({})) }));
+    vi.doMock('./agent', () => ({ createHeartbeatAgent: vi.fn().mockResolvedValue({}) }));
+    vi.doMock('../telemetry/tracer', () => ({
+      tracer: {
+        startTrace: vi.fn().mockReturnValue({
+          rootSpan: { setAttribute: vi.fn(), addEvent: vi.fn(), endWithError: vi.fn() },
+          finish: vi.fn().mockResolvedValue(undefined),
+        }),
+      },
+    }));
+    vi.doMock('../telemetry/semantics', () => ({
+      LLM_ATTRS: { SYSTEM: 'a', MODEL: 'b' },
+      HEARTBEAT_ATTRS: { TASK_COUNT: 'c', TASK_ID: 'd', HAS_CHANGES: 'e' },
+    }));
+    vi.doMock('../store/heartbeatStore', () => ({
+      loadHeartbeatState: vi.fn().mockResolvedValue({ lastChecked: 0, recentResults: [] }),
+      addHeartbeatResult: vi.fn().mockResolvedValue(undefined),
+      updateLastChecked: vi.fn().mockResolvedValue(undefined),
+      updateTaskLastRun: vi.fn().mockResolvedValue(undefined),
+      getTaskLastRun: vi.fn().mockResolvedValue(0),
+    }));
+
+    const { HeartbeatEngine: FreshEngine } = await import('./heartbeat');
+    const engine = new FreshEngine(() => []);
+    engine.start();
+
+    // 1 回目の tick で executeCheck 開始（実行中）
+    await vi.advanceTimersByTimeAsync(60_000);
+    // 2 回目の tick → isExecuting=true なのでスキップされる
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // run は 1 回しか呼ばれない（2回目はスキップ）
+    expect(mockRunSlow).toHaveBeenCalledTimes(1);
+
+    engine.stop();
+  });
+
+  it('enabled=false でスキップする', async () => {
+    const mockRunFn = vi.fn();
+    vi.resetModules();
+    vi.doMock('../store/db', async () => await import('../store/__mocks__/db'));
+    vi.doMock('./config', () => ({
+      getConfig: vi.fn().mockReturnValue({
+        openaiApiKey: 'sk-test',
+        heartbeat: {
+          enabled: false,
+          intervalMinutes: 1,
+          quietHoursStart: 0, quietHoursEnd: 0,
+          tasks: [{ id: 't', name: 't', description: 't', enabled: true, type: 'custom' as const }],
+          desktopNotification: false,
+        },
+      }),
+    }));
+    vi.doMock('@openai/agents', () => ({ run: mockRunFn, user: (msg: string) => ({ role: 'user', content: msg }) }));
+    vi.doMock('@openai/agents-openai', () => ({ setDefaultOpenAIClient: vi.fn() }));
+    vi.doMock('openai', () => ({ default: vi.fn().mockImplementation(() => ({})) }));
+    vi.doMock('./agent', () => ({ createHeartbeatAgent: vi.fn().mockResolvedValue({}) }));
+    vi.doMock('../telemetry/tracer', () => ({
+      tracer: {
+        startTrace: vi.fn().mockReturnValue({
+          rootSpan: { setAttribute: vi.fn(), addEvent: vi.fn(), endWithError: vi.fn() },
+          finish: vi.fn().mockResolvedValue(undefined),
+        }),
+      },
+    }));
+    vi.doMock('../telemetry/semantics', () => ({
+      LLM_ATTRS: { SYSTEM: 'a', MODEL: 'b' },
+      HEARTBEAT_ATTRS: { TASK_COUNT: 'c', TASK_ID: 'd', HAS_CHANGES: 'e' },
+    }));
+    vi.doMock('../store/heartbeatStore', () => ({
+      loadHeartbeatState: vi.fn().mockResolvedValue({ lastChecked: 0, recentResults: [] }),
+      addHeartbeatResult: vi.fn().mockResolvedValue(undefined),
+      updateLastChecked: vi.fn().mockResolvedValue(undefined),
+      updateTaskLastRun: vi.fn().mockResolvedValue(undefined),
+      getTaskLastRun: vi.fn().mockResolvedValue(0),
+    }));
+
+    const { HeartbeatEngine: FreshEngine } = await import('./heartbeat');
+    const engine = new FreshEngine(() => []);
+    engine.start();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(mockRunFn).not.toHaveBeenCalled();
+    engine.stop();
+  });
+
+  it('quiet hours 内でスキップする', async () => {
+    vi.setSystemTime(new Date(2025, 0, 1, 3, 0, 0));
+    const mockRunFn = vi.fn();
+    vi.resetModules();
+    vi.doMock('../store/db', async () => await import('../store/__mocks__/db'));
+    vi.doMock('./config', () => ({
+      getConfig: vi.fn().mockReturnValue({
+        openaiApiKey: 'sk-test',
+        heartbeat: {
+          enabled: true,
+          intervalMinutes: 1,
+          quietHoursStart: 0, quietHoursEnd: 6,
+          tasks: [{ id: 't', name: 't', description: 't', enabled: true, type: 'custom' as const }],
+          desktopNotification: false,
+        },
+      }),
+    }));
+    vi.doMock('@openai/agents', () => ({ run: mockRunFn, user: (msg: string) => ({ role: 'user', content: msg }) }));
+    vi.doMock('@openai/agents-openai', () => ({ setDefaultOpenAIClient: vi.fn() }));
+    vi.doMock('openai', () => ({ default: vi.fn().mockImplementation(() => ({})) }));
+    vi.doMock('./agent', () => ({ createHeartbeatAgent: vi.fn().mockResolvedValue({}) }));
+    vi.doMock('../telemetry/tracer', () => ({
+      tracer: {
+        startTrace: vi.fn().mockReturnValue({
+          rootSpan: { setAttribute: vi.fn(), addEvent: vi.fn(), endWithError: vi.fn() },
+          finish: vi.fn().mockResolvedValue(undefined),
+        }),
+      },
+    }));
+    vi.doMock('../telemetry/semantics', () => ({
+      LLM_ATTRS: { SYSTEM: 'a', MODEL: 'b' },
+      HEARTBEAT_ATTRS: { TASK_COUNT: 'c', TASK_ID: 'd', HAS_CHANGES: 'e' },
+    }));
+    vi.doMock('../store/heartbeatStore', () => ({
+      loadHeartbeatState: vi.fn().mockResolvedValue({ lastChecked: 0, recentResults: [] }),
+      addHeartbeatResult: vi.fn().mockResolvedValue(undefined),
+      updateLastChecked: vi.fn().mockResolvedValue(undefined),
+      updateTaskLastRun: vi.fn().mockResolvedValue(undefined),
+      getTaskLastRun: vi.fn().mockResolvedValue(0),
+    }));
+
+    const { HeartbeatEngine: FreshEngine } = await import('./heartbeat');
+    const engine = new FreshEngine(() => []);
+    engine.start();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(mockRunFn).not.toHaveBeenCalled();
+    engine.stop();
+  });
+
+  it('実行すべきタスクなしでスキップする', async () => {
+    const mockRunFn = vi.fn();
+    vi.resetModules();
+    vi.doMock('../store/db', async () => await import('../store/__mocks__/db'));
+    vi.doMock('./config', () => ({
+      getConfig: vi.fn().mockReturnValue({
+        openaiApiKey: 'sk-test',
+        heartbeat: {
+          enabled: true,
+          intervalMinutes: 1,
+          quietHoursStart: 0, quietHoursEnd: 0,
+          tasks: [],
+          desktopNotification: false,
+        },
+      }),
+    }));
+    vi.doMock('@openai/agents', () => ({ run: mockRunFn, user: (msg: string) => ({ role: 'user', content: msg }) }));
+    vi.doMock('@openai/agents-openai', () => ({ setDefaultOpenAIClient: vi.fn() }));
+    vi.doMock('openai', () => ({ default: vi.fn().mockImplementation(() => ({})) }));
+    vi.doMock('./agent', () => ({ createHeartbeatAgent: vi.fn().mockResolvedValue({}) }));
+    vi.doMock('../telemetry/tracer', () => ({
+      tracer: {
+        startTrace: vi.fn().mockReturnValue({
+          rootSpan: { setAttribute: vi.fn(), addEvent: vi.fn(), endWithError: vi.fn() },
+          finish: vi.fn().mockResolvedValue(undefined),
+        }),
+      },
+    }));
+    vi.doMock('../telemetry/semantics', () => ({
+      LLM_ATTRS: { SYSTEM: 'a', MODEL: 'b' },
+      HEARTBEAT_ATTRS: { TASK_COUNT: 'c', TASK_ID: 'd', HAS_CHANGES: 'e' },
+    }));
+    vi.doMock('../store/heartbeatStore', () => ({
+      loadHeartbeatState: vi.fn().mockResolvedValue({ lastChecked: 0, recentResults: [] }),
+      addHeartbeatResult: vi.fn().mockResolvedValue(undefined),
+      updateLastChecked: vi.fn().mockResolvedValue(undefined),
+      updateTaskLastRun: vi.fn().mockResolvedValue(undefined),
+      getTaskLastRun: vi.fn().mockResolvedValue(0),
+    }));
+
+    const { HeartbeatEngine: FreshEngine } = await import('./heartbeat');
+    const engine = new FreshEngine(() => []);
+    engine.start();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(mockRunFn).not.toHaveBeenCalled();
+    engine.stop();
+  });
+});
+
+describe('HeartbeatEngine - runNow', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: new Date(2025, 0, 1, 12, 0, 0) });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('tick を即時呼び出す', async () => {
+    const mockRunFn = vi.fn().mockResolvedValue({
+      finalOutput: JSON.stringify({
+        results: [{ taskId: 'test', hasChanges: false, summary: '' }],
+      }),
+    });
+
+    vi.resetModules();
+    vi.doMock('../store/db', async () => await import('../store/__mocks__/db'));
+    vi.doMock('./config', () => ({
+      getConfig: vi.fn().mockReturnValue({
+        openaiApiKey: 'sk-test',
+        heartbeat: {
+          enabled: true,
+          intervalMinutes: 1,
+          quietHoursStart: 0, quietHoursEnd: 0,
+          tasks: [{ id: 'test', name: 'test', description: 'test', enabled: true, type: 'custom' as const }],
+          desktopNotification: false,
+        },
+      }),
+    }));
+    vi.doMock('@openai/agents', () => ({ run: mockRunFn, user: (msg: string) => ({ role: 'user', content: msg }) }));
+    vi.doMock('@openai/agents-openai', () => ({ setDefaultOpenAIClient: vi.fn() }));
+    vi.doMock('openai', () => ({ default: vi.fn().mockImplementation(() => ({})) }));
+    vi.doMock('./agent', () => ({ createHeartbeatAgent: vi.fn().mockResolvedValue({}) }));
+    vi.doMock('../telemetry/tracer', () => ({
+      tracer: {
+        startTrace: vi.fn().mockReturnValue({
+          rootSpan: { setAttribute: vi.fn(), addEvent: vi.fn(), endWithError: vi.fn() },
+          finish: vi.fn().mockResolvedValue(undefined),
+        }),
+      },
+    }));
+    vi.doMock('../telemetry/semantics', () => ({
+      LLM_ATTRS: { SYSTEM: 'a', MODEL: 'b' },
+      HEARTBEAT_ATTRS: { TASK_COUNT: 'c', TASK_ID: 'd', HAS_CHANGES: 'e' },
+    }));
+    vi.doMock('../store/heartbeatStore', () => ({
+      loadHeartbeatState: vi.fn().mockResolvedValue({ lastChecked: 0, recentResults: [] }),
+      addHeartbeatResult: vi.fn().mockResolvedValue(undefined),
+      updateLastChecked: vi.fn().mockResolvedValue(undefined),
+      updateTaskLastRun: vi.fn().mockResolvedValue(undefined),
+      getTaskLastRun: vi.fn().mockResolvedValue(0),
+    }));
+
+    const { HeartbeatEngine: FreshEngine } = await import('./heartbeat');
+    const engine = new FreshEngine(() => []);
+    engine.start();
+
+    await engine.runNow();
+
+    expect(mockRunFn).toHaveBeenCalledTimes(1);
+    engine.stop();
+  });
+});

--- a/src/core/mcpClient.test.ts
+++ b/src/core/mcpClient.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mockConnect = vi.fn().mockResolvedValue(undefined);
+const mockClose = vi.fn().mockResolvedValue(undefined);
+const mockListTools = vi.fn();
+const mockCallTool = vi.fn();
+
+const mockClient = {
+  connect: mockConnect,
+  close: mockClose,
+  listTools: mockListTools,
+  callTool: mockCallTool,
+};
+
+const mockTerminateSession = vi.fn().mockResolvedValue(undefined);
+const mockTransportClose = vi.fn().mockResolvedValue(undefined);
+let mockSessionId: string | undefined = undefined;
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: vi.fn().mockImplementation(() => mockClient),
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: vi.fn().mockImplementation(() => ({
+    get sessionId() {
+      return mockSessionId;
+    },
+    terminateSession: mockTerminateSession,
+    close: mockTransportClose,
+  })),
+}));
+
+vi.mock('@modelcontextprotocol/sdk/types.js', () => ({
+  ListToolsResultSchema: {
+    parse: (v: unknown) => v,
+  },
+  CallToolResultSchema: {
+    parse: (v: unknown) => v,
+  },
+}));
+
+import { BrowserMCPServer } from './mcpClient';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSessionId = undefined;
+});
+
+describe('BrowserMCPServer', () => {
+  it('name プロパティが正しく返る', () => {
+    const server = new BrowserMCPServer({ name: 'test-server', url: 'http://localhost:3000' });
+    expect(server.name).toBe('test-server');
+  });
+
+  describe('connect', () => {
+    it('transport + client が初期化される', async () => {
+      const server = new BrowserMCPServer({ name: 'test', url: 'http://localhost:3000' });
+      await server.connect();
+      expect(mockConnect).toHaveBeenCalledOnce();
+    });
+
+    it('client.connect 失敗時に close して再スローする', async () => {
+      mockConnect.mockRejectedValueOnce(new Error('接続失敗'));
+      const server = new BrowserMCPServer({ name: 'test', url: 'http://localhost:3000' });
+
+      await expect(server.connect()).rejects.toThrow('接続失敗');
+      // close が呼ばれてクリーンアップされる
+      expect(mockTransportClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('close', () => {
+    it('sessionId ありで terminateSession を呼び出す', async () => {
+      mockSessionId = 'session-123';
+      const server = new BrowserMCPServer({ name: 'test', url: 'http://localhost:3000' });
+      await server.connect();
+
+      await server.close();
+      expect(mockTerminateSession).toHaveBeenCalledOnce();
+      expect(mockTransportClose).toHaveBeenCalled();
+    });
+
+    it('sessionId なしで terminateSession を呼ばない', async () => {
+      mockSessionId = undefined;
+      const server = new BrowserMCPServer({ name: 'test', url: 'http://localhost:3000' });
+      await server.connect();
+
+      await server.close();
+      expect(mockTerminateSession).not.toHaveBeenCalled();
+      expect(mockTransportClose).toHaveBeenCalled();
+    });
+
+    it('connect 前でも安全に呼べる', async () => {
+      const server = new BrowserMCPServer({ name: 'test', url: 'http://localhost:3000' });
+      await expect(server.close()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('listTools', () => {
+    it('未接続でエラーを投げる', async () => {
+      const server = new BrowserMCPServer({ name: 'test', url: 'http://localhost:3000' });
+      await expect(server.listTools()).rejects.toThrow('Server not initialized');
+    });
+
+    it('初回は SDK 呼び出し、2回目はキャッシュを返す', async () => {
+      const mockTools = { tools: [{ name: 'tool1', description: 'desc', inputSchema: {} }] };
+      mockListTools.mockResolvedValue(mockTools);
+
+      const server = new BrowserMCPServer({ name: 'test', url: 'http://localhost:3000' });
+      await server.connect();
+
+      const first = await server.listTools();
+      const second = await server.listTools();
+
+      expect(first).toEqual(mockTools.tools);
+      expect(second).toEqual(mockTools.tools);
+      // SDK は 1 回しか呼ばれない
+      expect(mockListTools).toHaveBeenCalledTimes(1);
+    });
+
+    it('cacheToolsList=false で毎回 SDK を呼び出す', async () => {
+      const mockTools = { tools: [{ name: 'tool1', description: 'desc', inputSchema: {} }] };
+      mockListTools.mockResolvedValue(mockTools);
+
+      const server = new BrowserMCPServer({ name: 'test', url: 'http://localhost:3000' });
+      server.cacheToolsList = false;
+      await server.connect();
+
+      await server.listTools();
+      await server.listTools();
+
+      expect(mockListTools).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('invalidateToolsCache', () => {
+    it('キャッシュ無効化後に再取得する', async () => {
+      const mockTools = { tools: [{ name: 'tool1', description: 'desc', inputSchema: {} }] };
+      mockListTools.mockResolvedValue(mockTools);
+
+      const server = new BrowserMCPServer({ name: 'test', url: 'http://localhost:3000' });
+      await server.connect();
+
+      await server.listTools(); // キャッシュ作成
+      expect(mockListTools).toHaveBeenCalledTimes(1);
+
+      await server.invalidateToolsCache();
+      await server.listTools(); // 再取得
+      expect(mockListTools).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('callTool', () => {
+    it('未接続でエラーを投げる', async () => {
+      const server = new BrowserMCPServer({ name: 'test', url: 'http://localhost:3000' });
+      await expect(server.callTool('tool1', {})).rejects.toThrow('Server not initialized');
+    });
+
+    it('args が正しく伝搬され、null は {} に変換される', async () => {
+      const mockResult = { content: [{ type: 'text', text: 'result' }] };
+      mockCallTool.mockResolvedValue(mockResult);
+
+      const server = new BrowserMCPServer({ name: 'test', url: 'http://localhost:3000' });
+      await server.connect();
+
+      // null args
+      await server.callTool('tool1', null);
+      expect(mockCallTool).toHaveBeenCalledWith({
+        name: 'tool1',
+        arguments: {},
+      });
+
+      // explicit args
+      mockCallTool.mockClear();
+      await server.callTool('tool2', { key: 'value' });
+      expect(mockCallTool).toHaveBeenCalledWith({
+        name: 'tool2',
+        arguments: { key: 'value' },
+      });
+    });
+  });
+});

--- a/src/core/mcpManager.test.ts
+++ b/src/core/mcpManager.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MCPManager } from './mcpManager';
+import type { MCPServerConfig } from '../types';
+
+const mockConnect = vi.fn().mockResolvedValue(undefined);
+const mockClose = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('./mcpClient', () => ({
+  BrowserMCPServer: vi.fn().mockImplementation(() => ({
+    connect: mockConnect,
+    close: mockClose,
+  })),
+}));
+
+function makeConfig(overrides?: Partial<MCPServerConfig>): MCPServerConfig {
+  return {
+    id: 'server-1',
+    name: 'テストサーバー',
+    url: 'http://localhost:3000/mcp',
+    enabled: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('MCPManager', () => {
+  describe('connectServer', () => {
+    it('接続成功で status=connected になる', async () => {
+      const manager = new MCPManager();
+      await manager.connectServer(makeConfig());
+
+      expect(manager.getStatus('server-1')).toBe('connected');
+    });
+
+    it('接続失敗で status=error + エラーメッセージが設定される', async () => {
+      mockConnect.mockRejectedValueOnce(new Error('接続拒否'));
+      const manager = new MCPManager();
+      await manager.connectServer(makeConfig());
+
+      expect(manager.getStatus('server-1')).toBe('error');
+      expect(manager.getError('server-1')).toBe('接続拒否');
+    });
+
+    it('既存接続を先に切断して再接続する', async () => {
+      const manager = new MCPManager();
+      await manager.connectServer(makeConfig());
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+
+      await manager.connectServer(makeConfig());
+      // 旧接続の close + 新接続の connect
+      expect(mockClose).toHaveBeenCalledTimes(1);
+      expect(mockConnect).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('disconnectServer', () => {
+    it('接続切断 + マップから削除される', async () => {
+      const manager = new MCPManager();
+      await manager.connectServer(makeConfig());
+      expect(manager.getStatus('server-1')).toBe('connected');
+
+      await manager.disconnectServer('server-1');
+      expect(mockClose).toHaveBeenCalledOnce();
+      expect(manager.getStatus('server-1')).toBe('disconnected');
+    });
+
+    it('存在しないIDで何もしない', async () => {
+      const manager = new MCPManager();
+      await expect(manager.disconnectServer('non-existent')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('disconnectAll', () => {
+    it('全接続を切断する', async () => {
+      const manager = new MCPManager();
+      await manager.connectServer(makeConfig({ id: 'a', name: 'A' }));
+      await manager.connectServer(makeConfig({ id: 'b', name: 'B' }));
+
+      await manager.disconnectAll();
+      expect(manager.getStatus('a')).toBe('disconnected');
+      expect(manager.getStatus('b')).toBe('disconnected');
+    });
+  });
+
+  describe('getActiveServers', () => {
+    it('connected のサーバーのみ返す', async () => {
+      mockConnect
+        .mockResolvedValueOnce(undefined) // a: 成功
+        .mockRejectedValueOnce(new Error('失敗')); // b: 失敗
+
+      const manager = new MCPManager();
+      await manager.connectServer(makeConfig({ id: 'a', name: 'A' }));
+      await manager.connectServer(makeConfig({ id: 'b', name: 'B' }));
+
+      const active = manager.getActiveServers();
+      expect(active).toHaveLength(1);
+    });
+  });
+
+  describe('getStatus', () => {
+    it('未登録IDで disconnected を返す', () => {
+      const manager = new MCPManager();
+      expect(manager.getStatus('unknown')).toBe('disconnected');
+    });
+  });
+
+  describe('subscribe', () => {
+    it('リスナー登録・解除が動作する', async () => {
+      const manager = new MCPManager();
+      const listener = vi.fn();
+
+      const unsubscribe = manager.subscribe(listener);
+      await manager.connectServer(makeConfig());
+      // connecting + connected の 2 回通知
+      expect(listener).toHaveBeenCalled();
+
+      listener.mockClear();
+      unsubscribe();
+      await manager.disconnectServer('server-1');
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('接続操作でリスナーに通知される', async () => {
+      const manager = new MCPManager();
+      const listener = vi.fn();
+      manager.subscribe(listener);
+
+      await manager.connectServer(makeConfig());
+      // connectServer は connecting + connected の 2 回 notify する
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('syncWithConfig', () => {
+    it('新規 enabled サーバーを接続する', async () => {
+      const manager = new MCPManager();
+      await manager.syncWithConfig([makeConfig()]);
+
+      expect(manager.getStatus('server-1')).toBe('connected');
+    });
+
+    it('disabled / 消えたサーバーを切断する', async () => {
+      const manager = new MCPManager();
+      await manager.connectServer(makeConfig({ id: 'old' }));
+      expect(manager.getStatus('old')).toBe('connected');
+
+      // old は configs から消えた → 切断される
+      await manager.syncWithConfig([makeConfig({ id: 'new' })]);
+      expect(manager.getStatus('old')).toBe('disconnected');
+      expect(manager.getStatus('new')).toBe('connected');
+    });
+
+    it('URL 変更で再接続する', async () => {
+      const manager = new MCPManager();
+      await manager.connectServer(makeConfig());
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+
+      // URL が変わった → 再接続
+      await manager.syncWithConfig([makeConfig({ url: 'http://localhost:4000/mcp' })]);
+      expect(mockConnect).toHaveBeenCalledTimes(2);
+    });
+
+    it('URL 同じで connected なら再接続しない', async () => {
+      const manager = new MCPManager();
+      await manager.connectServer(makeConfig());
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+
+      // 同じ設定で再 sync → 再接続されない
+      await manager.syncWithConfig([makeConfig()]);
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/core/mcpManager.ts
+++ b/src/core/mcpManager.ts
@@ -11,7 +11,7 @@ interface ManagedServer {
   error?: string;
 }
 
-class MCPManager {
+export class MCPManager {
   private servers = new Map<string, ManagedServer>();
   private listeners = new Set<() => void>();
 

--- a/src/store/calendarStore.test.ts
+++ b/src/store/calendarStore.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { __resetStores } from './__mocks__/db';
+
+vi.mock('./db');
+
+import { listEvents, createEvent, deleteEvent } from './calendarStore';
+
+beforeEach(() => {
+  __resetStores();
+});
+
+describe('listEvents', () => {
+  it('イベントなしで空配列を返す', async () => {
+    const events = await listEvents();
+    expect(events).toEqual([]);
+  });
+
+  it('複数イベントを全件返す', async () => {
+    await createEvent({ title: 'ミーティング', date: '2026-02-25' });
+    await createEvent({ title: 'ランチ', date: '2026-02-26' });
+
+    const events = await listEvents();
+    expect(events).toHaveLength(2);
+  });
+
+  it('日付指定で該当イベントのみ返す', async () => {
+    await createEvent({ title: 'ミーティング', date: '2026-02-25' });
+    await createEvent({ title: 'ランチ', date: '2026-02-26' });
+
+    const events = await listEvents('2026-02-25');
+    expect(events).toHaveLength(1);
+    expect(events[0].title).toBe('ミーティング');
+  });
+
+  it('該当日なしで空配列を返す', async () => {
+    await createEvent({ title: 'ミーティング', date: '2026-02-25' });
+
+    const events = await listEvents('2026-03-01');
+    expect(events).toEqual([]);
+  });
+});
+
+describe('createEvent', () => {
+  it('id, createdAt が自動付与される', async () => {
+    const event = await createEvent({ title: '会議', date: '2026-02-25' });
+    expect(event.id).toBeDefined();
+    expect(typeof event.id).toBe('string');
+    expect(event.createdAt).toBeDefined();
+    expect(typeof event.createdAt).toBe('number');
+  });
+
+  it('作成後に listEvents で取得できる', async () => {
+    const created = await createEvent({ title: '打合せ', date: '2026-02-25' });
+
+    const events = await listEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].id).toBe(created.id);
+    expect(events[0].title).toBe('打合せ');
+  });
+
+  it('optional フィールド（time, description）なしで動作する', async () => {
+    const event = await createEvent({ title: '終日イベント', date: '2026-02-25' });
+    expect(event.time).toBeUndefined();
+    expect(event.description).toBeUndefined();
+    expect(event.title).toBe('終日イベント');
+  });
+});
+
+describe('deleteEvent', () => {
+  it('存在するイベントを削除し true を返す', async () => {
+    const event = await createEvent({ title: '削除対象', date: '2026-02-25' });
+
+    const result = await deleteEvent(event.id);
+    expect(result).toBe(true);
+
+    const events = await listEvents();
+    expect(events).toHaveLength(0);
+  });
+
+  it('存在しないIDで false を返す', async () => {
+    const result = await deleteEvent('non-existent-id');
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- `calendarStore.ts` のユニットテスト新規作成（9テスト、0% → 100%）
- `mcpClient.ts` のユニットテスト新規作成（12テスト、0% → 98.76%）
- `mcpManager.ts` のユニットテスト新規作成（14テスト、0% → 98.82%）
- `heartbeat.ts` の executeCheck/tick/runNow テスト追加（+12テスト、51.53% → 96.31%）
- `MCPManager` クラスに named export 追加（テスト間の状態分離のため）
- `docs/ROADMAP.md` にコンポーネント/フック/E2E テストの中長期計画を追加

| 指標 | Before | After |
|---|---|---|
| テスト数 | 126 | **173** (+47) |
| Statements | 53.4% | **86.45%** |

## Test plan
- [x] `npm test` — 173 テスト全通過
- [x] `npm run test:coverage` — Statements 86.45%（目標 70% 超過達成）
- [x] `npm run build` — ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)