### PR TITLE
docs: MIT ライセンスを追加しリポジトリ公開準備

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 NAKAYAMA Masahiro
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # iAgent
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 ブラウザ上で動作するパーソナルAIアシスタント。OpenAI Agents SDK を活用し、リアルタイムストリーミング、バックグラウンドチェック（Heartbeat）、MCP サーバー連携をサポートする PWA アプリケーション。
 
 ## 技術スタック
@@ -170,3 +172,7 @@ GitHub Actions（`.github/workflows/ci.yml`）で main ブランチへの push /
 
 - [アーキテクチャ詳細](docs/ARCHITECTURE.md)
 - [ロードマップ](docs/ROADMAP.md)
+
+## ライセンス
+
+[MIT License](LICENSE) の下で公開されています。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iagent",
-  "private": true,
   "version": "0.0.0",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- MIT LICENSE ファイルを新規作成（Copyright 2026 NAKAYAMA Masahiro）
- README.md に MIT バッジとライセンスセクションを追加
- package.json から `"private": true` を削除し `"license": "MIT"` を設定

## Test plan
- [ ] `npm test` — 全 369 テスト通過を確認済み
- [ ] `npm run build` — ビルド成功を確認済み
- [ ] LICENSE ファイルの内容が標準的な MIT ライセンス文であることを確認
- [ ] README のバッジリンクが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)