### PR TITLE
feat: アイデンティティ + 記憶フレームワーク Phase D

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,8 @@
 - Heartbeat バックグラウンドチェック（4 ビルトインタスク: カレンダー、天気、フィード、Web 監視）
 - デスクトップ通知（Notification API）
 - PWA（カスタム Service Worker + injectManifest、インストール可能）
-- エージェント長期メモリ（memoryTool + 自動コンテキスト注入）
+- エージェント長期メモリ（構造化記憶 — importance/tags/カテゴリ拡張 + 関連性ベース取得）
+- エージェントペルソナ設定（名前・性格・口調・追加指示のカスタマイズ + 動的 instruction 構築）
 - マルチステップタスク実行 + TaskProgress 進捗UI
 - カスタムワークフロー（タスクごとの個別スケジュール設定）
 - オブザーバビリティ基盤（OTel 互換トレーサー + OTLP/HTTP エクスポーター）
@@ -22,7 +23,7 @@
 - Heartbeat 3層構成（メインスレッド + Dedicated Worker + Service Worker/Push）
 - CORS プロキシ（Cloudflare Workers 拡張 — トークン認証 + SSRF 防止 + レート制限）
 - セキュリティ基盤（CSP ヘッダー + URL HTTPS 強制バリデーション）
-- テスト 369 件
+- テスト 422 件
 
 ---
 
@@ -101,6 +102,9 @@
 - [x] `memoryTool.ts`（save / search / list / delete）
 - [x] ユーザーの好みや過去のやり取りを蓄積
 - [x] Heartbeat タスクのパーソナライズに活用
+- [x] 構造化記憶 — importance(1-5)/tags/カテゴリ拡張（routine, goal, personality 追加）
+- [x] 関連性ベースの記憶取得（スコアリング: キーワード一致 + importance + カテゴリボーナス + 時間近接性）
+- [x] 後方互換 normalizeMemory（既存データのフォールバック）
 
 ### マルチステップタスク実行
 - [x] エージェント instructions にタスク分解戦略を追加
@@ -151,6 +155,14 @@
 - [x] MCP ツールの Heartbeat 対応（read-only ツール許可リスト + 設定 UI）
 - [ ] MCP プリセット UI（Notion, GitHub 等の人気サーバーをワンクリック追加）
 
+### エージェントアイデンティティ + 記憶フレームワーク（Phase D）
+- [x] Memory Enhancement — 構造化記憶（importance/tags/新カテゴリ）+ 関連性ベース取得 + 後方互換
+- [x] Agent Persona — PersonaConfig 型 + getDefaultPersonaConfig + 設定 UI（名前・性格・口調・追加指示）
+- [x] Instruction Builder — buildMainInstructions/buildHeartbeatInstructions/buildWorkerHeartbeatPrompt（全 7 ツールガイド + メモリ管理ガイドライン + プロアクティブ行動）
+- [x] Integration — agent.ts/heartbeatOpenAI.ts/heartbeatCommon.ts に persona + instructionBuilder 統合
+- [x] DB_VERSION 8→9（memories ストアに importance/tags インデックス追加）
+- [ ] ペルソナプリセット配布 + インポート機能
+
 ### エージェント自律性強化
 - [ ] 情報収集ワークフロー（RSS ダイジェスト、ニュースブリーフィング等の Heartbeat タスク）
 - [ ] プロアクティブ提案エンジン（日次ブリーフィング、関連情報サジェスト）
@@ -191,3 +203,4 @@
 - [x] セキュリティ基盤整備 — MCP URL HTTPS 強制バリデーション + CSP meta タグ（本番ビルド）（2026-02-26）
 - [x] CORS プロキシ — Cloudflare Workers 拡張（トークン認証 + SSRF 防止 + レート制限 + クライアント設定 UI）（2026-02-26）
 - [x] 外部情報収集ツール Phase C — クリッピング（clipTool + clipStore）、RSS フィード（feedTool + feedParser + feedStore + Heartbeat 連携）、Web ページ監視（webMonitorTool + monitorStore + Heartbeat 連携）、MCP Heartbeat 対応（read-only ツール許可 + 設定 UI）。DB_VERSION 7→8、4 新ストア追加。テスト 263→369 件。（2026-02-26）
+- [x] アイデンティティ + 記憶フレームワーク Phase D — 構造化記憶（importance/tags/新カテゴリ + 関連性ベース取得 + normalizeMemory 後方互換）、Agent Persona（PersonaConfig + 設定 UI + 動的 instructionBuilder）、全コンポーネント統合（agent.ts/heartbeatOpenAI.ts/heartbeatCommon.ts）。DB_VERSION 8→9。テスト 369→422 件。（2026-02-26）

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -48,6 +48,12 @@ vi.mock('../core/config', () => ({
     authToken: '',
     allowedDomains: [],
   })),
+  getDefaultPersonaConfig: vi.fn(() => ({
+    name: 'iAgent',
+    personality: '',
+    tone: '',
+    customInstructions: '',
+  })),
   BUILTIN_HEARTBEAT_TASKS: [],
 }));
 
@@ -131,8 +137,10 @@ describe('SettingsModal', () => {
 
     expect(screen.getByText('MCPサーバーが未登録です')).toBeInTheDocument();
 
-    // MCP Servers セクション内の「+ 追加」ボタンをクリック
-    const mcpSection = container.querySelector('.mcp-section')!;
+    // MCP Servers セクション内の「+ 追加」ボタンをクリック（エージェント設定の次のセクション）
+    const mcpSections = container.querySelectorAll('.mcp-section');
+    // MCP Servers はエージェント設定の次のセクション
+    const mcpSection = Array.from(mcpSections).find((s) => s.textContent?.includes('MCP Servers'))!;
     const addButton = mcpSection.querySelector('.btn-secondary')!;
     await userEvent.click(addButton);
 
@@ -145,7 +153,8 @@ describe('SettingsModal', () => {
     const { container } = render(<SettingsModal open={true} onClose={vi.fn()} />);
 
     // MCP Servers セクション内の「+ 追加」ボタンをクリック
-    const mcpSection = container.querySelector('.mcp-section')!;
+    const mcpSections = container.querySelectorAll('.mcp-section');
+    const mcpSection = Array.from(mcpSections).find((s) => s.textContent?.includes('MCP Servers'))!;
     const addButton = mcpSection.querySelector('.btn-secondary')!;
     await userEvent.click(addButton);
     expect(screen.getByPlaceholderText('サーバー名')).toBeInTheDocument();

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,12 +1,12 @@
 import { useState, useEffect, useCallback } from 'react';
-import { getConfig, saveConfig, getDefaultHeartbeatConfig, getDefaultOtelConfig, getDefaultProxyConfig, BUILTIN_HEARTBEAT_TASKS } from '../core/config';
+import { getConfig, saveConfig, getDefaultHeartbeatConfig, getDefaultOtelConfig, getDefaultProxyConfig, getDefaultPersonaConfig, BUILTIN_HEARTBEAT_TASKS } from '../core/config';
 import { mcpManager, type MCPConnectionStatus } from '../core/mcpManager';
 import { getNotificationPermission, requestNotificationPermission } from '../core/notifier';
 import { subscribePush, unsubscribePush, getPushSubscription, registerPeriodicSync, unregisterPeriodicSync } from '../core/pushSubscription';
 import { registerProxyToken } from '../core/corsProxy';
 import { getUrlValidationError } from '../core/urlValidation';
 import { isReadOnlyTool } from '../core/agent';
-import type { AppConfig, MCPServerConfig, HeartbeatConfig, HeartbeatTask, TaskSchedule, OtelConfig, PushConfig, ProxyConfig } from '../types';
+import type { AppConfig, MCPServerConfig, HeartbeatConfig, HeartbeatTask, TaskSchedule, OtelConfig, PushConfig, ProxyConfig, PersonaConfig } from '../types';
 
 interface Props {
   open: boolean;
@@ -41,6 +41,7 @@ export function SettingsModal({ open, onClose }: Props) {
     if (open) setConfig(getConfig());
   }, [open]);
 
+  const persona: PersonaConfig = config.persona ?? getDefaultPersonaConfig();
   const heartbeat = config.heartbeat ?? getDefaultHeartbeatConfig();
   const push: PushConfig = config.push ?? { enabled: false, serverUrl: '' };
   const proxy: ProxyConfig = config.proxy ?? getDefaultProxyConfig();
@@ -82,6 +83,13 @@ export function SettingsModal({ open, onClose }: Props) {
     if (!open) return;
     mcpManager.getAvailableTools().then(setMcpToolsList).catch(() => setMcpToolsList([]));
   }, [open]);
+
+  const updatePersona = (patch: Partial<PersonaConfig>) => {
+    setConfig((prev) => ({
+      ...prev,
+      persona: { ...persona, ...patch },
+    }));
+  };
 
   const updateProxy = (patch: Partial<ProxyConfig>) => {
     setConfig((prev) => ({
@@ -272,6 +280,52 @@ export function SettingsModal({ open, onClose }: Props) {
             placeholder="..."
           />
         </label>
+
+        {/* エージェント設定 */}
+        <div className="mcp-section">
+          <h3>エージェント設定</h3>
+          <p className="mcp-hint">エージェントの名前や性格をカスタマイズできます。</p>
+
+          <label>
+            エージェント名
+            <input
+              type="text"
+              value={persona.name}
+              onChange={(e) => updatePersona({ name: e.target.value })}
+              placeholder="iAgent"
+            />
+          </label>
+
+          <label>
+            性格・特徴
+            <input
+              type="text"
+              value={persona.personality}
+              onChange={(e) => updatePersona({ personality: e.target.value })}
+              placeholder="例: 丁寧で親しみやすい"
+            />
+          </label>
+
+          <label>
+            話し方
+            <input
+              type="text"
+              value={persona.tone}
+              onChange={(e) => updatePersona({ tone: e.target.value })}
+              placeholder="例: カジュアル"
+            />
+          </label>
+
+          <label>
+            追加指示
+            <textarea
+              value={persona.customInstructions}
+              onChange={(e) => updatePersona({ customInstructions: e.target.value })}
+              placeholder="エージェントへの追加指示を自由に記述"
+              rows={3}
+            />
+          </label>
+        </div>
 
         <div className="mcp-section">
           <div className="mcp-header">

--- a/src/core/agent.test.ts
+++ b/src/core/agent.test.ts
@@ -3,8 +3,15 @@ import { __resetStores } from '../store/__mocks__/db';
 
 vi.mock('../store/db');
 
+// configStore モック
+vi.mock('../store/configStore', () => ({
+  saveConfigToIDB: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { createAgent, createHeartbeatAgent } from './agent';
 import { saveMemory } from '../store/memoryStore';
+import { saveConfig, getDefaultHeartbeatConfig, getDefaultPersonaConfig } from './config';
+import type { AppConfig } from '../types';
 
 // Agent クラスをモックして instructions とツールを検証可能にする
 vi.mock('@openai/agents', () => {
@@ -41,6 +48,7 @@ vi.mock('../tools/memoryTool', () => ({
 
 beforeEach(() => {
   __resetStores();
+  localStorage.clear();
 });
 
 describe('createAgent', () => {
@@ -59,7 +67,7 @@ describe('createAgent', () => {
     expect(agent.instructions).toContain('[preference] 朝にニュースを確認したい');
   });
 
-  it('instructions にタスク分解方針が含まれる', async () => {
+  it('instructions にタスク実行方針が含まれる', async () => {
     const agent = await createAgent() as unknown as { instructions: string };
     expect(agent.instructions).toContain('タスク実行方針');
     expect(agent.instructions).toContain('必要なステップを特定する');
@@ -71,10 +79,56 @@ describe('createAgent', () => {
     expect(toolNames).toContain('memory');
   });
 
-  it('メモリについての指示が instructions に含まれる', async () => {
+  it('メモリ管理ガイドラインが instructions に含まれる', async () => {
     const agent = await createAgent() as unknown as { instructions: string };
-    expect(agent.instructions).toContain('メモリについて');
-    expect(agent.instructions).toContain('memory ツールの save アクション');
+    expect(agent.instructions).toContain('メモリ管理ガイドライン');
+  });
+
+  it('instructions に全ツール名が含まれる', async () => {
+    const agent = await createAgent() as unknown as { instructions: string };
+    expect(agent.instructions).toContain('calendar');
+    expect(agent.instructions).toContain('web_search');
+    expect(agent.instructions).toContain('device_info');
+    expect(agent.instructions).toContain('memory');
+    expect(agent.instructions).toContain('clip');
+    expect(agent.instructions).toContain('feed');
+    expect(agent.instructions).toContain('web_monitor');
+  });
+
+  it('persona.name が Agent の name に反映される', async () => {
+    const config: AppConfig = {
+      openaiApiKey: 'sk-test',
+      braveApiKey: '',
+      openWeatherMapApiKey: '',
+      mcpServers: [],
+      heartbeat: getDefaultHeartbeatConfig(),
+      persona: { ...getDefaultPersonaConfig(), name: 'MyBot' },
+    };
+    saveConfig(config);
+
+    const agent = await createAgent() as unknown as { name: string; instructions: string };
+    expect(agent.name).toBe('MyBot');
+    expect(agent.instructions).toContain('MyBot');
+  });
+
+  it('persona の personality が instructions に反映される', async () => {
+    const config: AppConfig = {
+      openaiApiKey: 'sk-test',
+      braveApiKey: '',
+      openWeatherMapApiKey: '',
+      mcpServers: [],
+      heartbeat: getDefaultHeartbeatConfig(),
+      persona: { ...getDefaultPersonaConfig(), personality: '丁寧で親しみやすい' },
+    };
+    saveConfig(config);
+
+    const agent = await createAgent() as unknown as { instructions: string };
+    expect(agent.instructions).toContain('丁寧で親しみやすい');
+  });
+
+  it('デフォルトペルソナで name が iAgent になる', async () => {
+    const agent = await createAgent() as unknown as { name: string };
+    expect(agent.name).toBe('iAgent');
   });
 });
 
@@ -90,5 +144,27 @@ describe('createHeartbeatAgent', () => {
     const agent = await createHeartbeatAgent() as unknown as { instructions: string };
     expect(agent.instructions).toContain('ユーザーについての記憶');
     expect(agent.instructions).toContain('[fact] ユーザーは東京在住');
+  });
+
+  it('persona.name が Heartbeat Agent の name に反映される', async () => {
+    const config: AppConfig = {
+      openaiApiKey: 'sk-test',
+      braveApiKey: '',
+      openWeatherMapApiKey: '',
+      mcpServers: [],
+      heartbeat: getDefaultHeartbeatConfig(),
+      persona: { ...getDefaultPersonaConfig(), name: 'MyBot' },
+    };
+    saveConfig(config);
+
+    const agent = await createHeartbeatAgent() as unknown as { name: string };
+    expect(agent.name).toBe('MyBot-Heartbeat');
+  });
+
+  it('JSON 出力形式が instructions に含まれる', async () => {
+    const agent = await createHeartbeatAgent() as unknown as { instructions: string };
+    expect(agent.instructions).toContain('"taskId"');
+    expect(agent.instructions).toContain('"hasChanges"');
+    expect(agent.instructions).toContain('JSON形式');
   });
 });

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -7,35 +7,23 @@ import { memoryTool } from '../tools/memoryTool';
 import { clipTool } from '../tools/clipTool';
 import { feedTool } from '../tools/feedTool';
 import { webMonitorTool } from '../tools/webMonitorTool';
-import { getRecentMemories } from '../store/memoryStore';
+import { getRelevantMemories } from '../store/memoryStore';
+import { getConfig, getDefaultPersonaConfig } from './config';
+import { buildMainInstructions, buildHeartbeatInstructions } from './instructionBuilder';
 
 export async function createAgent(mcpServers?: MCPServer[]): Promise<Agent> {
-  const memories = await getRecentMemories(10);
-  const memoryContext = memories.length > 0
-    ? `\n\n## あなたの記憶\n以下はこれまでに保存した重要な情報です:\n${memories.map((m) => `- [${m.category}] ${m.content}`).join('\n')}`
-    : '';
+  const config = getConfig();
+  const persona = config.persona ?? getDefaultPersonaConfig();
+  const memories = await getRelevantMemories('', 10);
+  const instructions = buildMainInstructions({
+    persona,
+    memories,
+    currentDateTime: new Date().toLocaleString('ja-JP'),
+  });
 
   return new Agent({
-    name: 'iAgent',
-    instructions: `あなたはiAgentです。ブラウザ上で動作するパーソナルAIアシスタントです。
-ユーザーの質問に答え、必要に応じてツールを使用してタスクを実行します。
-ツールの結果を受け取ったら、ユーザーにわかりやすく日本語で説明してください。
-日付や時刻に関する操作では、ユーザーのローカルタイムゾーンを考慮してください。
-現在の日時: ${new Date().toLocaleString('ja-JP')}
-
-## タスク実行方針
-複数のステップが必要なタスクでは、以下の手順で進めてください:
-1. まずユーザーの依頼を分析し、必要なステップを特定する
-2. 各ステップで適切なツールを呼び出す
-3. 前のステップの結果を踏まえて次のステップを実行する
-4. すべてのステップが完了したら、結果を統合してわかりやすく報告する
-
-例: 「明日の予定を確認して、天気も調べて」
-→ カレンダーツールで予定確認 → デバイス情報ツールで天気取得 → 統合して報告
-
-## メモリについて
-ユーザーとの会話で重要な情報（好み、事実、文脈）を発見したら、memory ツールの save アクションで保存してください。
-既に保存済みの情報を更新する場合は、古いメモリを delete してから新しい内容で save してください。${memoryContext}`,
+    name: persona.name || 'iAgent',
+    instructions,
     model: 'gpt-5-mini',
     tools: [calendarTool, webSearchTool, deviceInfoTool, memoryTool, clipTool, feedTool, webMonitorTool],
     mcpServers: mcpServers && mcpServers.length > 0 ? mcpServers : undefined,
@@ -54,10 +42,15 @@ export async function createHeartbeatAgent(
   mcpServers?: MCPServer[],
   allowedMcpToolNames?: string[],
 ): Promise<Agent> {
-  const memories = await getRecentMemories(5);
-  const memoryContext = memories.length > 0
-    ? `\n\nユーザーについての記憶:\n${memories.map((m) => `- [${m.category}] ${m.content}`).join('\n')}`
-    : '';
+  const config = getConfig();
+  const persona = config.persona ?? getDefaultPersonaConfig();
+  const memories = await getRelevantMemories('', 5);
+  const instructions = buildHeartbeatInstructions({
+    persona,
+    memories,
+    currentDateTime: new Date().toLocaleString('ja-JP'),
+    isHeartbeat: true,
+  });
 
   // MCP ツールが指定されていない場合は MCP サーバーを渡さない
   const filteredMcpServers = allowedMcpToolNames && allowedMcpToolNames.length > 0
@@ -69,26 +62,8 @@ export async function createHeartbeatAgent(
     : '';
 
   return new Agent({
-    name: 'iAgent-Heartbeat',
-    instructions: `あなたはiAgentのバックグラウンドチェッカーです。
-与えられたタスクに基づいて定期チェックを実行し、結果をJSON形式で返してください。
-
-必ず以下のJSON形式で回答してください（他のテキストは含めないでください）:
-{
-  "results": [
-    {
-      "taskId": "タスクID",
-      "hasChanges": true/false,
-      "summary": "変化の要約（変化がない場合は空文字列）"
-    }
-  ]
-}
-
-現在の日時: ${new Date().toLocaleString('ja-JP')}
-ルール:
-- hasChanges が false の場合、summary は空文字列にしてください
-- 通知する価値がある情報のみ hasChanges: true にしてください
-- 日本語で summary を書いてください${memoryContext}${mcpToolNote}`,
+    name: `${persona.name || 'iAgent'}-Heartbeat`,
+    instructions: instructions + mcpToolNote,
     model: 'gpt-5-nano',
     tools: [calendarTool, deviceInfoTool],
     mcpServers: filteredMcpServers && filteredMcpServers.length > 0 ? filteredMcpServers : undefined,

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -8,6 +8,7 @@ vi.mock('../store/configStore', () => ({
 import {
   BUILTIN_HEARTBEAT_TASKS,
   getDefaultHeartbeatConfig,
+  getDefaultPersonaConfig,
   getConfig,
   saveConfig,
   getConfigValue,
@@ -123,6 +124,60 @@ describe('getConfigValue', () => {
     saveConfig(saved);
     expect(getConfigValue('openaiApiKey')).toBe('sk-value');
     expect(getConfigValue('braveApiKey')).toBe('brave-value');
+  });
+});
+
+describe('getDefaultPersonaConfig', () => {
+  it('デフォルト値を返す', () => {
+    const persona = getDefaultPersonaConfig();
+    expect(persona.name).toBe('iAgent');
+    expect(persona.personality).toBe('');
+    expect(persona.tone).toBe('');
+    expect(persona.customInstructions).toBe('');
+  });
+
+  it('呼び出しごとに新しいオブジェクトを返す', () => {
+    const a = getDefaultPersonaConfig();
+    const b = getDefaultPersonaConfig();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('persona in getConfig', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('persona 未設定時にデフォルトが返る', () => {
+    const config = getConfig();
+    expect(config.persona).toEqual(getDefaultPersonaConfig());
+  });
+
+  it('部分的な persona がマージされる', () => {
+    localStorage.setItem('iagent-config', JSON.stringify({
+      openaiApiKey: 'sk-test',
+      persona: { name: 'MyBot', personality: '元気' },
+    }));
+    const config = getConfig();
+    expect(config.persona!.name).toBe('MyBot');
+    expect(config.persona!.personality).toBe('元気');
+    expect(config.persona!.tone).toBe('');
+    expect(config.persona!.customInstructions).toBe('');
+  });
+
+  it('完全な persona がそのまま返る', () => {
+    const fullPersona = {
+      name: 'テストボット',
+      personality: '丁寧で親しみやすい',
+      tone: 'カジュアル',
+      customInstructions: '常に日本語で回答',
+    };
+    localStorage.setItem('iagent-config', JSON.stringify({
+      openaiApiKey: 'sk-test',
+      persona: fullPersona,
+    }));
+    const config = getConfig();
+    expect(config.persona).toEqual(fullPersona);
   });
 });
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,4 +1,4 @@
-import type { AppConfig, ConfigKey, HeartbeatConfig, HeartbeatTask, OtelConfig, ProxyConfig } from '../types';
+import type { AppConfig, ConfigKey, HeartbeatConfig, HeartbeatTask, OtelConfig, PersonaConfig, ProxyConfig } from '../types';
 import { saveConfigToIDB } from '../store/configStore';
 
 const STORAGE_KEY = 'iagent-config';
@@ -53,6 +53,15 @@ export function getDefaultOtelConfig(): OtelConfig {
   };
 }
 
+export function getDefaultPersonaConfig(): PersonaConfig {
+  return {
+    name: 'iAgent',
+    personality: '',
+    tone: '',
+    customInstructions: '',
+  };
+}
+
 export function getDefaultHeartbeatConfig(): HeartbeatConfig {
   return {
     enabled: false,
@@ -67,7 +76,7 @@ export function getDefaultHeartbeatConfig(): HeartbeatConfig {
 export function getConfig(): AppConfig {
   const raw = localStorage.getItem(STORAGE_KEY);
   if (!raw) {
-    return { openaiApiKey: '', braveApiKey: '', openWeatherMapApiKey: '', mcpServers: [], heartbeat: getDefaultHeartbeatConfig(), push: { enabled: false, serverUrl: '' }, proxy: getDefaultProxyConfig(), otel: getDefaultOtelConfig() };
+    return { openaiApiKey: '', braveApiKey: '', openWeatherMapApiKey: '', mcpServers: [], heartbeat: getDefaultHeartbeatConfig(), push: { enabled: false, serverUrl: '' }, proxy: getDefaultProxyConfig(), otel: getDefaultOtelConfig(), persona: getDefaultPersonaConfig() };
   }
   const parsed = JSON.parse(raw) as Partial<AppConfig>;
   return {
@@ -85,6 +94,9 @@ export function getConfig(): AppConfig {
     otel: parsed.otel
       ? { ...getDefaultOtelConfig(), ...parsed.otel }
       : getDefaultOtelConfig(),
+    persona: parsed.persona
+      ? { ...getDefaultPersonaConfig(), ...parsed.persona }
+      : getDefaultPersonaConfig(),
   };
 }
 

--- a/src/core/heartbeatCommon.ts
+++ b/src/core/heartbeatCommon.ts
@@ -3,6 +3,7 @@ import { loadConfigFromIDB } from '../store/configStore';
 import { loadHeartbeatState, addHeartbeatResult, updateTaskLastRun, getTaskLastRun } from '../store/heartbeatStore';
 import { executeWorkerHeartbeatCheck } from './heartbeatOpenAI';
 import { getDB } from '../store/db';
+import { getDefaultPersonaConfig } from './config';
 import type { HeartbeatConfig, HeartbeatResult, HeartbeatSource, HeartbeatTask, CalendarEvent, Memory } from '../types';
 
 /** IndexedDB から最新設定を読み込み、API キーと Heartbeat 設定を返す */
@@ -90,11 +91,15 @@ export async function executeHeartbeatAndStore(apiKey: string, source?: Heartbea
   const calendarEvents: CalendarEvent[] = await db.getAll('calendar');
   const memories: Memory[] = await db.getAll('memories');
 
+  // persona を取得（未設定時はデフォルト）
+  const persona = freshConfig?.persona ?? getDefaultPersonaConfig();
+
   const results = await executeWorkerHeartbeatCheck(
     resolvedApiKey,
     tasks,
     calendarEvents,
     memories.slice(0, 5),
+    persona,
   );
 
   const now = Date.now();

--- a/src/core/heartbeatOpenAI.test.ts
+++ b/src/core/heartbeatOpenAI.test.ts
@@ -3,8 +3,13 @@ import { __resetStores } from '../store/__mocks__/db';
 
 vi.mock('../store/db');
 
+// configStore モック
+vi.mock('../store/configStore', () => ({
+  saveConfigToIDB: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { callChatCompletions, executeWorkerHeartbeatCheck } from './heartbeatOpenAI';
-import type { HeartbeatTask, Memory } from '../types';
+import type { HeartbeatTask, Memory, PersonaConfig } from '../types';
 
 const mockFetch = vi.fn();
 globalThis.fetch = mockFetch;
@@ -151,7 +156,7 @@ describe('executeWorkerHeartbeatCheck', () => {
 
   it('メモリが含まれるとシステムプロンプトに注入される', async () => {
     const memoryList: Memory[] = [
-      { id: '1', content: 'ユーザーは朝が苦手', category: 'preference', createdAt: 0, updatedAt: 0 },
+      { id: '1', content: 'ユーザーは朝が苦手', category: 'preference', importance: 3, tags: [], createdAt: 0, updatedAt: 0 },
     ];
     const apiResponse = {
       choices: [{
@@ -169,6 +174,51 @@ describe('executeWorkerHeartbeatCheck', () => {
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
     const systemMsg = body.messages.find((m: { role: string }) => m.role === 'system');
     expect(systemMsg.content).toContain('ユーザーは朝が苦手');
+  });
+
+  it('persona が反映される', async () => {
+    const persona: PersonaConfig = {
+      name: 'TestBot',
+      personality: '冷静沈着',
+      tone: '',
+      customInstructions: '',
+    };
+    const apiResponse = {
+      choices: [{
+        message: {
+          role: 'assistant',
+          content: JSON.stringify({ results: [] }),
+        },
+        finish_reason: 'stop',
+      }],
+    };
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve(apiResponse) });
+
+    await executeWorkerHeartbeatCheck('sk-test', tasks, [], [], persona);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const systemMsg = body.messages.find((m: { role: string }) => m.role === 'system');
+    expect(systemMsg.content).toContain('TestBot');
+    expect(systemMsg.content).toContain('冷静沈着');
+  });
+
+  it('persona 未指定時はデフォルトの iAgent が使われる', async () => {
+    const apiResponse = {
+      choices: [{
+        message: {
+          role: 'assistant',
+          content: JSON.stringify({ results: [] }),
+        },
+        finish_reason: 'stop',
+      }],
+    };
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve(apiResponse) });
+
+    await executeWorkerHeartbeatCheck('sk-test', tasks, [], []);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const systemMsg = body.messages.find((m: { role: string }) => m.role === 'system');
+    expect(systemMsg.content).toContain('iAgent');
   });
 
   it('content が空の場合は空配列を返す', async () => {

--- a/src/core/heartbeatOpenAI.ts
+++ b/src/core/heartbeatOpenAI.ts
@@ -1,5 +1,7 @@
 import { WORKER_TOOLS, executeWorkerTool } from './heartbeatTools';
-import type { HeartbeatResult, HeartbeatTask, CalendarEvent, Memory } from '../types';
+import { buildWorkerHeartbeatPrompt } from './instructionBuilder';
+import { getDefaultPersonaConfig } from './config';
+import type { HeartbeatResult, HeartbeatTask, CalendarEvent, Memory, PersonaConfig } from '../types';
 
 const OPENAI_API_URL = import.meta.env.VITE_OPENAI_API_URL
   || 'https://api.openai.com/v1/chat/completions';
@@ -88,30 +90,13 @@ export async function callChatCompletions(
 }
 
 /** Heartbeat 用システムプロンプトを構築する */
-function buildSystemPrompt(memories: Memory[]): string {
-  const memoryContext = memories.length > 0
-    ? `\n\nユーザーについての記憶:\n${memories.map((m) => `- [${m.category}] ${m.content}`).join('\n')}`
-    : '';
-
-  return `あなたはiAgentのバックグラウンドチェッカーです。
-与えられたタスクに基づいて定期チェックを実行し、結果をJSON形式で返してください。
-
-必ず以下のJSON形式で回答してください（他のテキストは含めないでください）:
-{
-  "results": [
-    {
-      "taskId": "タスクID",
-      "hasChanges": true/false,
-      "summary": "変化の要約（変化がない場合は空文字列）"
-    }
-  ]
-}
-
-現在の日時: ${new Date().toLocaleString('ja-JP')}
-ルール:
-- hasChanges が false の場合、summary は空文字列にしてください
-- 通知する価値がある情報のみ hasChanges: true にしてください
-- 日本語で summary を書いてください${memoryContext}`;
+function buildSystemPrompt(memories: Memory[], persona?: PersonaConfig): string {
+  return buildWorkerHeartbeatPrompt({
+    persona: persona ?? getDefaultPersonaConfig(),
+    memories,
+    currentDateTime: new Date().toLocaleString('ja-JP'),
+    isHeartbeat: true,
+  });
 }
 
 /** Worker 内で Heartbeat チェックを実行する（DOM/localStorage 非依存） */
@@ -120,8 +105,9 @@ export async function executeWorkerHeartbeatCheck(
   tasks: HeartbeatTask[],
   calendarEvents: CalendarEvent[],
   memories: Memory[],
+  persona?: PersonaConfig,
 ): Promise<HeartbeatResult[]> {
-  const systemPrompt = buildSystemPrompt(memories);
+  const systemPrompt = buildSystemPrompt(memories, persona);
   const taskDescriptions = tasks.map((t) =>
     `- タスクID: ${t.id}, タスク名: ${t.name}, 内容: ${t.description}`
   ).join('\n');

--- a/src/core/instructionBuilder.test.ts
+++ b/src/core/instructionBuilder.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import { buildMainInstructions, buildHeartbeatInstructions, buildWorkerHeartbeatPrompt } from './instructionBuilder';
+import type { InstructionContext } from './instructionBuilder';
+import { getDefaultPersonaConfig } from './config';
+import type { Memory } from '../types';
+
+function makeContext(overrides?: Partial<InstructionContext>): InstructionContext {
+  return {
+    persona: getDefaultPersonaConfig(),
+    memories: [],
+    currentDateTime: '2026/2/26 12:00:00',
+    ...overrides,
+  };
+}
+
+function makeMemory(overrides?: Partial<Memory>): Memory {
+  return {
+    id: 'mem-1',
+    content: 'テスト用メモリ',
+    category: 'fact',
+    importance: 3,
+    tags: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('buildMainInstructions', () => {
+  it('デフォルトペルソナ名 iAgent を含む', () => {
+    const result = buildMainInstructions(makeContext());
+    expect(result).toContain('iAgent');
+  });
+
+  it('カスタムペルソナ名を含む', () => {
+    const result = buildMainInstructions(makeContext({
+      persona: { ...getDefaultPersonaConfig(), name: 'MyBot' },
+    }));
+    expect(result).toContain('MyBot');
+    expect(result).not.toContain('あなたはiAgentです');
+  });
+
+  it('personality 設定時に含まれる', () => {
+    const result = buildMainInstructions(makeContext({
+      persona: { ...getDefaultPersonaConfig(), personality: '丁寧で親しみやすい' },
+    }));
+    expect(result).toContain('丁寧で親しみやすい');
+  });
+
+  it('personality 未設定時に「性格・特徴」セクションが含まれない', () => {
+    const result = buildMainInstructions(makeContext());
+    expect(result).not.toContain('性格・特徴:');
+  });
+
+  it('tone 設定時に含まれる', () => {
+    const result = buildMainInstructions(makeContext({
+      persona: { ...getDefaultPersonaConfig(), tone: 'カジュアル' },
+    }));
+    expect(result).toContain('カジュアル');
+  });
+
+  it('customInstructions 設定時に含まれる', () => {
+    const result = buildMainInstructions(makeContext({
+      persona: { ...getDefaultPersonaConfig(), customInstructions: '常に英語で回答' },
+    }));
+    expect(result).toContain('常に英語で回答');
+    expect(result).toContain('ユーザーからの追加指示');
+  });
+
+  it('全7ツール名を含む', () => {
+    const result = buildMainInstructions(makeContext());
+    expect(result).toContain('calendar');
+    expect(result).toContain('web_search');
+    expect(result).toContain('device_info');
+    expect(result).toContain('memory');
+    expect(result).toContain('clip');
+    expect(result).toContain('feed');
+    expect(result).toContain('web_monitor');
+  });
+
+  it('タスク実行方針を含む', () => {
+    const result = buildMainInstructions(makeContext());
+    expect(result).toContain('タスク実行方針');
+    expect(result).toContain('必要なステップを特定する');
+  });
+
+  it('メモリ管理ガイドラインを含む', () => {
+    const result = buildMainInstructions(makeContext());
+    expect(result).toContain('メモリ管理ガイドライン');
+    expect(result).toContain('routine');
+    expect(result).toContain('goal');
+    expect(result).toContain('personality');
+  });
+
+  it('プロアクティブ行動を含む', () => {
+    const result = buildMainInstructions(makeContext());
+    expect(result).toContain('プロアクティブ行動');
+  });
+
+  it('メモリコンテキストを含む', () => {
+    const memories = [
+      makeMemory({ content: 'ユーザーは東京在住', category: 'fact' }),
+      makeMemory({ id: 'mem-2', content: '朝7時に起床', category: 'routine' }),
+    ];
+    const result = buildMainInstructions(makeContext({ memories }));
+    expect(result).toContain('あなたの記憶');
+    expect(result).toContain('[fact] ユーザーは東京在住');
+    expect(result).toContain('[routine] 朝7時に起床');
+  });
+
+  it('メモリ 0 件でもエラーにならない', () => {
+    const result = buildMainInstructions(makeContext({ memories: [] }));
+    expect(result).not.toContain('あなたの記憶');
+  });
+
+  it('importance が 3 以外の場合に表示される', () => {
+    const memories = [makeMemory({ content: '重要情報', importance: 5 })];
+    const result = buildMainInstructions(makeContext({ memories }));
+    expect(result).toContain('(重要度:5)');
+  });
+
+  it('importance が 3 の場合は表示されない', () => {
+    const memories = [makeMemory({ content: 'デフォルト重要度', importance: 3 })];
+    const result = buildMainInstructions(makeContext({ memories }));
+    expect(result).not.toContain('(重要度:3)');
+  });
+
+  it('tags が表示される', () => {
+    const memories = [makeMemory({ content: 'タグ付き', tags: ['tokyo', 'weather'] })];
+    const result = buildMainInstructions(makeContext({ memories }));
+    expect(result).toContain('#tokyo');
+    expect(result).toContain('#weather');
+  });
+
+  it('日時コンテキストを含む', () => {
+    const result = buildMainInstructions(makeContext({ currentDateTime: '2026/3/1 09:00:00' }));
+    expect(result).toContain('2026/3/1 09:00:00');
+  });
+});
+
+describe('buildHeartbeatInstructions', () => {
+  it('デフォルトペルソナ名を含む', () => {
+    const result = buildHeartbeatInstructions(makeContext());
+    expect(result).toContain('iAgent');
+  });
+
+  it('カスタムペルソナ名を含む', () => {
+    const result = buildHeartbeatInstructions(makeContext({
+      persona: { ...getDefaultPersonaConfig(), name: 'カスタム' },
+    }));
+    expect(result).toContain('カスタム');
+  });
+
+  it('JSON 出力形式要件を含む', () => {
+    const result = buildHeartbeatInstructions(makeContext());
+    expect(result).toContain('"taskId"');
+    expect(result).toContain('"hasChanges"');
+    expect(result).toContain('"summary"');
+    expect(result).toContain('JSON形式');
+  });
+
+  it('personality 設定時に反映される', () => {
+    const result = buildHeartbeatInstructions(makeContext({
+      persona: { ...getDefaultPersonaConfig(), personality: '冷静沈着' },
+    }));
+    expect(result).toContain('冷静沈着');
+  });
+
+  it('メモリコンテキストを含む', () => {
+    const memories = [makeMemory({ content: 'テストメモリ', category: 'preference' })];
+    const result = buildHeartbeatInstructions(makeContext({ memories }));
+    expect(result).toContain('ユーザーについての記憶');
+    expect(result).toContain('[preference] テストメモリ');
+  });
+
+  it('メモリ 0 件でも正常', () => {
+    const result = buildHeartbeatInstructions(makeContext({ memories: [] }));
+    expect(result).not.toContain('ユーザーについての記憶');
+  });
+});
+
+describe('buildWorkerHeartbeatPrompt', () => {
+  it('buildHeartbeatInstructions と同じ結果を返す', () => {
+    const ctx = makeContext();
+    expect(buildWorkerHeartbeatPrompt(ctx)).toBe(buildHeartbeatInstructions(ctx));
+  });
+
+  it('ペルソナ名を含む', () => {
+    const result = buildWorkerHeartbeatPrompt(makeContext({
+      persona: { ...getDefaultPersonaConfig(), name: 'WorkerBot' },
+    }));
+    expect(result).toContain('WorkerBot');
+  });
+});

--- a/src/core/instructionBuilder.ts
+++ b/src/core/instructionBuilder.ts
@@ -1,0 +1,154 @@
+import type { Memory, PersonaConfig } from '../types';
+
+export interface InstructionContext {
+  persona: PersonaConfig;
+  memories: Memory[];
+  currentDateTime: string;
+  isHeartbeat?: boolean;
+}
+
+/** メインエージェント用 instructions を構築する */
+export function buildMainInstructions(ctx: InstructionContext): string {
+  const sections: string[] = [];
+
+  // 1. ペルソナセクション
+  sections.push(buildPersonaSection(ctx.persona));
+
+  // 2. ツール使用ガイド
+  sections.push(`## ツール使用ガイド
+以下のツールを使用してユーザーを支援できます:
+- **calendar**: カレンダーの予定を管理（追加・一覧・削除）
+- **web_search**: Web検索で最新情報を取得
+- **device_info**: デバイス情報や天気情報を取得
+- **memory**: 長期メモリの保存・検索・管理
+- **clip**: Webページやテキストのクリッピング（構造化保存）
+- **feed**: RSSフィード購読の管理と記事取得
+- **web_monitor**: Webページの変化監視
+
+ツールを活用し、ユーザーの依頼に最適な方法で応えてください。`);
+
+  // 3. タスク実行方針
+  sections.push(`## タスク実行方針
+複数のステップが必要なタスクでは、以下の手順で進めてください:
+1. まずユーザーの依頼を分析し、必要なステップを特定する
+2. 各ステップで適切なツールを呼び出す
+3. 前のステップの結果を踏まえて次のステップを実行する
+4. すべてのステップが完了したら、結果を統合してわかりやすく報告する
+
+例: 「明日の予定を確認して、天気も調べて」
+→ カレンダーツールで予定確認 → デバイス情報ツールで天気取得 → 統合して報告`);
+
+  // 4. メモリ管理ガイドライン
+  sections.push(`## メモリ管理ガイドライン
+ユーザーとの会話で重要な情報を発見したら、memory ツールの save アクションで保存してください。
+
+**カテゴリの使い分け**:
+- preference: ユーザーの好み・嗜好
+- fact: 事実情報（住所、名前など）
+- context: 状況・文脈
+- routine: ユーザーの日課・習慣
+- goal: ユーザーの目標・締切
+- personality: エージェントの振る舞い指示
+
+**重要度（importance 1-5）**:
+- 5: 絶対に忘れてはいけない情報（名前、重要な締切等）
+- 3: 一般的な情報（デフォルト）
+- 1: 一時的な文脈情報
+
+**タグ**: 関連するキーワードをタグとして付与すると、後から検索しやすくなります。
+
+**保存タイミング**: ユーザーが明示的に「覚えて」と言った場合はもちろん、会話の中で重要な事実や好みを発見したら自発的に保存してください。
+既に保存済みの情報を更新する場合は、古いメモリを delete してから新しい内容で save してください。`);
+
+  // 5. プロアクティブ行動
+  sections.push(`## プロアクティブ行動
+以下の場面では自発的に行動してください:
+- ユーザーの発言から好みや重要な事実を検出したら、確認の上メモリに保存
+- 関連する過去の記憶がある場合は、会話に自然に組み込む
+- ユーザーの目標や日課に関連する情報を提供できる場合は積極的に提案`);
+
+  // 6. コンテキスト
+  const contextParts: string[] = [`## コンテキスト\n現在の日時: ${ctx.currentDateTime}`];
+  if (ctx.memories.length > 0) {
+    contextParts.push(`\n### あなたの記憶\n以下はこれまでに保存した重要な情報です:\n${formatMemories(ctx.memories)}`);
+  }
+  sections.push(contextParts.join(''));
+
+  return sections.join('\n\n');
+}
+
+/** Heartbeat エージェント用 instructions を構築する */
+export function buildHeartbeatInstructions(ctx: InstructionContext): string {
+  const sections: string[] = [];
+
+  // ペルソナ
+  const personaName = ctx.persona.name || 'iAgent';
+  sections.push(`あなたは${personaName}のバックグラウンドチェッカーです。`);
+
+  if (ctx.persona.personality) {
+    sections.push(`性格: ${ctx.persona.personality}`);
+  }
+
+  sections.push(`与えられたタスクに基づいて定期チェックを実行し、結果をJSON形式で返してください。
+
+必ず以下のJSON形式で回答してください（他のテキストは含めないでください）:
+{
+  "results": [
+    {
+      "taskId": "タスクID",
+      "hasChanges": true/false,
+      "summary": "変化の要約（変化がない場合は空文字列）"
+    }
+  ]
+}
+
+現在の日時: ${ctx.currentDateTime}
+ルール:
+- hasChanges が false の場合、summary は空文字列にしてください
+- 通知する価値がある情報のみ hasChanges: true にしてください
+- 日本語で summary を書いてください`);
+
+  // メモリ
+  if (ctx.memories.length > 0) {
+    sections.push(`ユーザーについての記憶:\n${formatMemories(ctx.memories)}`);
+  }
+
+  return sections.join('\n\n');
+}
+
+/** Worker Heartbeat 用システムプロンプトを構築する（heartbeatOpenAI.ts の buildSystemPrompt 代替） */
+export function buildWorkerHeartbeatPrompt(ctx: InstructionContext): string {
+  return buildHeartbeatInstructions(ctx);
+}
+
+/** ペルソナセクションを構築する */
+function buildPersonaSection(persona: PersonaConfig): string {
+  const personaName = persona.name || 'iAgent';
+  const lines: string[] = [
+    `あなたは${personaName}です。ブラウザ上で動作するパーソナルAIアシスタントです。`,
+    'ユーザーの質問に答え、必要に応じてツールを使用してタスクを実行します。',
+    'ツールの結果を受け取ったら、ユーザーにわかりやすく日本語で説明してください。',
+    '日付や時刻に関する操作では、ユーザーのローカルタイムゾーンを考慮してください。',
+  ];
+
+  if (persona.personality) {
+    lines.push(`\n性格・特徴: ${persona.personality}`);
+  }
+  if (persona.tone) {
+    lines.push(`話し方: ${persona.tone}`);
+  }
+  if (persona.customInstructions) {
+    lines.push(`\n### ユーザーからの追加指示\n${persona.customInstructions}`);
+  }
+
+  return lines.join('\n');
+}
+
+/** メモリ配列をフォーマットする */
+function formatMemories(memories: Memory[]): string {
+  return memories.map((m) => {
+    const tags = m.tags && m.tags.length > 0 ? ` #${m.tags.join(' #')}` : '';
+    const importance = m.importance && m.importance !== 3 ? ` (重要度:${m.importance})` : '';
+    return `- [${m.category}] ${m.content}${importance}${tags}`;
+  }).join('\n');
+}

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -1,7 +1,7 @@
 import { openDB, type IDBPDatabase } from 'idb';
 
 const DB_NAME = 'iagent-db';
-const DB_VERSION = 8;
+const DB_VERSION = 9;
 
 let dbPromise: Promise<IDBPDatabase> | null = null;
 
@@ -53,6 +53,16 @@ export function getDB(): Promise<IDBPDatabase> {
         }
         if (!db.objectStoreNames.contains('monitors')) {
           db.createObjectStore('monitors', { keyPath: 'id' });
+        }
+        // Phase D: memories ストアに importance/tags インデックス追加
+        if (db.objectStoreNames.contains('memories')) {
+          const memStore = transaction.objectStore('memories');
+          if (!memStore.indexNames.contains('importance')) {
+            memStore.createIndex('importance', 'importance', { unique: false });
+          }
+          if (!memStore.indexNames.contains('tags')) {
+            memStore.createIndex('tags', 'tags', { unique: false, multiEntry: true });
+          }
         }
         // conversations ストアに conversationId インデックス追加
         if (db.objectStoreNames.contains('conversations')) {

--- a/src/store/memoryStore.test.ts
+++ b/src/store/memoryStore.test.ts
@@ -9,10 +9,28 @@ import {
   listMemories,
   deleteMemory,
   getRecentMemories,
+  getRelevantMemories,
+  normalizeMemory,
 } from './memoryStore';
 
 beforeEach(() => {
   __resetStores();
+});
+
+describe('normalizeMemory', () => {
+  it('importance/tags が未設定の場合にデフォルト値を付与する', () => {
+    const raw = { id: '1', content: 'test', category: 'fact', createdAt: 100, updatedAt: 100 };
+    const normalized = normalizeMemory(raw);
+    expect(normalized.importance).toBe(3);
+    expect(normalized.tags).toEqual([]);
+  });
+
+  it('importance/tags が設定済みの場合はそのまま返す', () => {
+    const raw = { id: '1', content: 'test', category: 'fact', importance: 5, tags: ['a'], createdAt: 100, updatedAt: 100 };
+    const normalized = normalizeMemory(raw);
+    expect(normalized.importance).toBe(5);
+    expect(normalized.tags).toEqual(['a']);
+  });
 });
 
 describe('saveMemory', () => {
@@ -21,8 +39,48 @@ describe('saveMemory', () => {
     expect(memory.id).toBeDefined();
     expect(memory.content).toBe('ユーザーは東京在住');
     expect(memory.category).toBe('fact');
+    expect(memory.importance).toBe(3);
+    expect(memory.tags).toEqual([]);
     expect(memory.createdAt).toBeGreaterThan(0);
     expect(memory.updatedAt).toBe(memory.createdAt);
+  });
+
+  it('importance を指定して保存できる', async () => {
+    const memory = await saveMemory('重要な事実', 'fact', { importance: 5 });
+    expect(memory.importance).toBe(5);
+  });
+
+  it('tags を指定して保存できる', async () => {
+    const memory = await saveMemory('タグ付きメモリ', 'preference', { tags: ['tokyo', 'weather'] });
+    expect(memory.tags).toEqual(['tokyo', 'weather']);
+  });
+
+  it('importance の範囲外はクランプされる', async () => {
+    const low = await saveMemory('低すぎ', 'other', { importance: 0 });
+    expect(low.importance).toBe(1);
+    const high = await saveMemory('高すぎ', 'other', { importance: 10 });
+    expect(high.importance).toBe(5);
+  });
+
+  it('importance 省略時にデフォルト 3', async () => {
+    const memory = await saveMemory('デフォルト', 'other');
+    expect(memory.importance).toBe(3);
+  });
+
+  it('tags 省略時に空配列', async () => {
+    const memory = await saveMemory('タグなし', 'other');
+    expect(memory.tags).toEqual([]);
+  });
+
+  it('新カテゴリ（routine, goal, personality）で保存できる', async () => {
+    const routine = await saveMemory('毎朝7時にニュース確認', 'routine');
+    expect(routine.category).toBe('routine');
+
+    const goal = await saveMemory('3月末までにレポート提出', 'goal');
+    expect(goal.category).toBe('goal');
+
+    const personality = await saveMemory('敬語で話して', 'personality');
+    expect(personality.category).toBe('personality');
   });
 
   it('MAX_MEMORIES を超えたとき最古が削除される', async () => {
@@ -68,6 +126,13 @@ describe('searchMemories', () => {
     const results = await searchMemories('react');
     expect(results).toHaveLength(1);
     expect(results[0].content).toBe('React is preferred');
+  });
+
+  it('検索結果に normalizeMemory が適用される', async () => {
+    await saveMemory('テスト', 'fact');
+    const results = await searchMemories('テスト');
+    expect(results[0].importance).toBe(3);
+    expect(results[0].tags).toEqual([]);
   });
 });
 
@@ -141,5 +206,68 @@ describe('getRecentMemories', () => {
 
     const recent = await getRecentMemories();
     expect(recent).toHaveLength(10);
+  });
+});
+
+describe('getRelevantMemories', () => {
+  it('personality と routine カテゴリを常に含む', async () => {
+    await saveMemory('通常のメモリ1', 'fact', { importance: 5 });
+    await saveMemory('通常のメモリ2', 'fact', { importance: 5 });
+    await saveMemory('通常のメモリ3', 'fact', { importance: 5 });
+    await saveMemory('敬語で話して', 'personality');
+    await saveMemory('毎朝7時にニュース確認', 'routine');
+
+    const results = await getRelevantMemories('', 5);
+    const categories = results.map((m) => m.category);
+    expect(categories).toContain('personality');
+    expect(categories).toContain('routine');
+  });
+
+  it('キーワード一致でスコアリングする', async () => {
+    await saveMemory('東京の天気は晴れ', 'fact');
+    await saveMemory('大阪のグルメ情報', 'fact');
+    await saveMemory('横浜のイベント', 'fact');
+
+    const results = await getRelevantMemories('東京', 2);
+    expect(results[0].content).toContain('東京');
+  });
+
+  it('importance の高いメモリを優先する', async () => {
+    await saveMemory('低重要度', 'fact', { importance: 1 });
+    await saveMemory('高重要度', 'fact', { importance: 5 });
+
+    const results = await getRelevantMemories('', 2);
+    expect(results[0].content).toBe('高重要度');
+  });
+
+  it('tags 一致でスコアが上がる', async () => {
+    await saveMemory('タグなし', 'fact', { importance: 3 });
+    await saveMemory('タグあり', 'fact', { importance: 3, tags: ['東京'] });
+
+    const results = await getRelevantMemories('東京', 2);
+    expect(results[0].content).toBe('タグあり');
+  });
+
+  it('limit を超えない', async () => {
+    for (let i = 0; i < 20; i++) {
+      await saveMemory(`メモリ ${i}`, 'fact');
+    }
+
+    const results = await getRelevantMemories('', 5);
+    expect(results).toHaveLength(5);
+  });
+
+  it('メモリ 0 件でもエラーにならない', async () => {
+    const results = await getRelevantMemories('テスト', 10);
+    expect(results).toEqual([]);
+  });
+
+  it('空クエリでもスコアリングが動作する', async () => {
+    await saveMemory('メモリA', 'preference', { importance: 5 });
+    await saveMemory('メモリB', 'fact', { importance: 1 });
+
+    const results = await getRelevantMemories('', 2);
+    // preference(+2) + importance(5) = 7 > fact(+1) + importance(1) = 2
+    expect(results[0].content).toBe('メモリA');
   });
 });

--- a/src/store/memoryStore.ts
+++ b/src/store/memoryStore.ts
@@ -1,16 +1,33 @@
 import { getDB } from './db';
-import type { Memory } from '../types';
+import type { Memory, MemoryCategory } from '../types';
 
 const STORE_NAME = 'memories';
 const MAX_MEMORIES = 100;
 
-export async function saveMemory(content: string, category: Memory['category']): Promise<Memory> {
+/** 既存データの後方互換: importance/tags が未設定の場合にフォールバック */
+export function normalizeMemory(raw: Partial<Memory> & { id: string; content: string; category: string; createdAt: number; updatedAt: number }): Memory {
+  return {
+    ...raw,
+    category: raw.category as MemoryCategory,
+    importance: raw.importance ?? 3,
+    tags: raw.tags ?? [],
+  };
+}
+
+export async function saveMemory(
+  content: string,
+  category: MemoryCategory,
+  options?: { importance?: number; tags?: string[] },
+): Promise<Memory> {
   const db = await getDB();
   const now = Date.now();
+  const importance = Math.max(1, Math.min(5, options?.importance ?? 3));
   const memory: Memory = {
     id: crypto.randomUUID(),
     content,
     category,
+    importance,
+    tags: options?.tags ?? [],
     createdAt: now,
     updatedAt: now,
   };
@@ -26,21 +43,22 @@ export async function saveMemory(content: string, category: Memory['category']):
 
 export async function searchMemories(query: string): Promise<Memory[]> {
   const db = await getDB();
-  const all: Memory[] = await db.getAll(STORE_NAME);
+  const all = await db.getAll(STORE_NAME);
   const lowerQuery = query.toLowerCase();
-  return all
+  return (all as Memory[])
+    .map(normalizeMemory)
     .filter((m) => m.content.toLowerCase().includes(lowerQuery))
     .sort((a, b) => b.updatedAt - a.updatedAt);
 }
 
-export async function listMemories(category?: Memory['category']): Promise<Memory[]> {
+export async function listMemories(category?: MemoryCategory): Promise<Memory[]> {
   const db = await getDB();
   if (category) {
-    const results: Memory[] = await db.getAllFromIndex(STORE_NAME, 'category', category);
-    return results.sort((a, b) => b.updatedAt - a.updatedAt);
+    const results = await db.getAllFromIndex(STORE_NAME, 'category', category);
+    return (results as Memory[]).map(normalizeMemory).sort((a, b) => b.updatedAt - a.updatedAt);
   }
-  const all: Memory[] = await db.getAll(STORE_NAME);
-  return all.sort((a, b) => b.updatedAt - a.updatedAt);
+  const all = await db.getAll(STORE_NAME);
+  return (all as Memory[]).map(normalizeMemory).sort((a, b) => b.updatedAt - a.updatedAt);
 }
 
 export async function deleteMemory(id: string): Promise<boolean> {
@@ -54,4 +72,85 @@ export async function deleteMemory(id: string): Promise<boolean> {
 export async function getRecentMemories(limit: number = 10): Promise<Memory[]> {
   const all = await listMemories();
   return all.slice(0, limit);
+}
+
+/** 関連性ベースの記憶取得 */
+export async function getRelevantMemories(
+  query: string,
+  limit: number = 10,
+): Promise<Memory[]> {
+  const all = await listMemories();
+  const now = Date.now();
+  const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+
+  // クエリをトークン化
+  const queryTokens = query.toLowerCase().split(/\s+/).filter((t) => t.length > 0);
+
+  // カテゴリボーナス
+  const categoryBonus: Record<MemoryCategory, number> = {
+    personality: 5,
+    routine: 4,
+    goal: 3,
+    preference: 2,
+    fact: 1,
+    context: 1,
+    other: 0,
+  };
+
+  // スコアリング
+  const scored = all.map((m) => {
+    let score = 0;
+
+    // キーワード一致
+    if (queryTokens.length > 0) {
+      const lowerContent = m.content.toLowerCase();
+      const lowerTags = m.tags.map((t) => t.toLowerCase());
+      for (const token of queryTokens) {
+        if (lowerContent.includes(token)) score += 3;
+        if (lowerTags.some((tag) => tag.includes(token))) score += 2;
+      }
+    }
+
+    // importance 加算
+    score += m.importance;
+
+    // カテゴリボーナス
+    score += categoryBonus[m.category] ?? 0;
+
+    // 直近 7 日ボーナス
+    if (now - m.updatedAt < sevenDaysMs) score += 1;
+
+    return { memory: m, score };
+  });
+
+  // 必須メモリ（personality, routine）を先に抽出
+  const mustInclude = scored.filter(
+    (s) => s.memory.category === 'personality' || s.memory.category === 'routine',
+  );
+  const others = scored.filter(
+    (s) => s.memory.category !== 'personality' && s.memory.category !== 'routine',
+  );
+
+  // スコア降順ソート
+  mustInclude.sort((a, b) => b.score - a.score);
+  others.sort((a, b) => b.score - a.score);
+
+  // 必須メモリを優先し、残り枠を others から埋める
+  const result: Memory[] = [];
+  const usedIds = new Set<string>();
+
+  for (const s of mustInclude) {
+    if (result.length >= limit) break;
+    result.push(s.memory);
+    usedIds.add(s.memory.id);
+  }
+
+  for (const s of others) {
+    if (result.length >= limit) break;
+    if (!usedIds.has(s.memory.id)) {
+      result.push(s.memory);
+    }
+  }
+
+  return result;
 }

--- a/src/tools/memoryTool.ts
+++ b/src/tools/memoryTool.ts
@@ -1,30 +1,51 @@
 import { tool } from '@openai/agents';
 import { z } from 'zod';
 import { saveMemory, searchMemories, listMemories, deleteMemory } from '../store/memoryStore';
+import type { MemoryCategory } from '../types';
+
+const validCategories: MemoryCategory[] = ['preference', 'fact', 'context', 'routine', 'goal', 'personality', 'other'];
 
 export const memoryTool = tool({
   name: 'memory',
   description: `長期メモリを管理します。ユーザーの好み・重要な情報・文脈を保存し、後から参照できます。
 action:
-- "save": メモリを保存。content（内容）と category（preference/fact/context/other）を指定。
+- "save": メモリを保存。content（内容）と category を指定。importance（1-5）と tags（カンマ区切り）はオプション。
 - "search": キーワードでメモリを検索。query を指定。
 - "list": メモリ一覧を取得。category で絞り込み可能（空文字で全件）。
-- "delete": メモリを削除。id を指定。`,
+- "delete": メモリを削除。id を指定。
+
+category:
+- preference: ユーザーの好み・嗜好（例: 「コーヒーが好き」）
+- fact: 事実情報（例: 「東京在住」）
+- context: 文脈・状況（例: 「プロジェクトXに取り組み中」）
+- routine: ユーザーの日課・習慣（例: 「毎朝7時にニュース確認」）
+- goal: ユーザーの目標（例: 「3月末までにレポート提出」）
+- personality: エージェントの振る舞い指示（例: 「敬語で話して」）
+- other: その他`,
   parameters: z.object({
     action: z.enum(['save', 'search', 'list', 'delete']),
     content: z.string().describe('保存するメモリの内容。save 時に必須、他は空文字'),
-    category: z.string().describe('カテゴリ（preference/fact/context/other）。save 時に必須、list 時はフィルタ用、他は空文字'),
+    category: z.string().describe('カテゴリ（preference/fact/context/routine/goal/personality/other）。save 時に必須、list 時はフィルタ用、他は空文字'),
     query: z.string().describe('検索キーワード。search 時に必須、他は空文字'),
     id: z.string().describe('削除対象のメモリID。delete 時に必須、他は空文字'),
+    importance: z.string().optional().describe('重要度（1-5）。save 時のみ有効、省略時はデフォルト 3'),
+    tags: z.string().optional().describe('タグ（カンマ区切り）。save 時のみ有効、省略時は空'),
   }),
-  execute: async ({ action, content, category, query, id }) => {
+  execute: async ({ action, content, category, query, id, importance, tags }) => {
     if (action === 'save') {
       if (!content) return JSON.stringify({ error: 'content は必須です' });
-      const validCategories = ['preference', 'fact', 'context', 'other'] as const;
-      const cat = validCategories.includes(category as typeof validCategories[number])
-        ? (category as typeof validCategories[number])
+      const cat: MemoryCategory = validCategories.includes(category as MemoryCategory)
+        ? (category as MemoryCategory)
         : 'other';
-      const memory = await saveMemory(content, cat);
+      const options: { importance?: number; tags?: string[] } = {};
+      if (importance) {
+        const parsed = parseInt(importance, 10);
+        if (!isNaN(parsed)) options.importance = parsed;
+      }
+      if (tags) {
+        options.tags = tags.split(',').map((t) => t.trim()).filter((t) => t.length > 0);
+      }
+      const memory = await saveMemory(content, cat, options);
       return JSON.stringify({ message: 'メモリを保存しました', memory });
     }
 
@@ -35,9 +56,8 @@ action:
     }
 
     if (action === 'list') {
-      const validCategories = ['preference', 'fact', 'context', 'other'] as const;
-      const cat = validCategories.includes(category as typeof validCategories[number])
-        ? (category as typeof validCategories[number])
+      const cat: MemoryCategory | undefined = validCategories.includes(category as MemoryCategory)
+        ? (category as MemoryCategory)
         : undefined;
       const memories = await listMemories(cat);
       return JSON.stringify({ memories, count: memories.length });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -113,14 +113,26 @@ export interface AppConfig {
   push?: PushConfig;
   proxy?: ProxyConfig;
   otel?: OtelConfig;
+  persona?: PersonaConfig;
 }
+
+export type MemoryCategory = 'preference' | 'fact' | 'context' | 'routine' | 'goal' | 'personality' | 'other';
 
 export interface Memory {
   id: string;
   content: string;
-  category: 'preference' | 'fact' | 'context' | 'other';
+  category: MemoryCategory;
+  importance: number;   // 1-5, デフォルト 3
+  tags: string[];       // 自由形式タグ
   createdAt: number;
   updatedAt: number;
+}
+
+export interface PersonaConfig {
+  name: string;              // エージェント名 (デフォルト: 'iAgent')
+  personality: string;       // 性格・特徴の自由記述
+  tone: string;              // 話し方
+  customInstructions: string; // ユーザー独自の追加指示
 }
 
 /** getConfigValue() で文字列として取得可能なキー */


### PR DESCRIPTION
## Summary

- **D-1: Memory Enhancement** — Memory 型に importance(1-5)/tags/新カテゴリ(routine, goal, personality)追加。DB_VERSION 8→9。normalizeMemory() 後方互換。getRelevantMemories() 関連性ベース取得（スコアリング: キーワード一致+importance+カテゴリボーナス+時間近接性、personality/routine 必須含有）。memoryTool に importance/tags パラメータ追加
- **D-2: Agent Persona + Instruction Builder** — PersonaConfig 型 + getDefaultPersonaConfig()。instructionBuilder.ts 新規作成（全7ツールガイド+メモリ管理ガイドライン+プロアクティブ行動ガイダンス）。SettingsModal にエージェント設定セクション追加（名前・性格・口調・追加指示）
- **D-3: Integration** — agent.ts/heartbeatOpenAI.ts/heartbeatCommon.ts に persona + instructionBuilder 統合。buildSystemPrompt → buildWorkerHeartbeatPrompt 置換
- テスト 369→422 件（+53）、ビルド成功確認済み

## Test plan

- [x] `npm test` — 全 422 テスト通過
- [x] `npm run build` — ビルド成功
- [ ] 手動: チャットで「これを覚えて、重要度5で」→ importance=5 で保存確認
- [ ] 手動: 設定画面でエージェント名を変更 → チャットで反映確認
- [ ] 手動: routine/goal/personality カテゴリのメモリ保存と優先取得確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)