### PR TITLE
feat: バンドルサイズ削減 — manualChunks + 依存切断 + React.lazy

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -134,7 +134,7 @@
 - [ ] レスポンシブ改善（モバイル最適化）
 
 ### ビルド最適化
-- [ ] バンドルサイズ削減 — `dynamic import()` によるコード分割、`manualChunks` でベンダーチャンク分離（現在 index.js が 920KB 超で 500KB 警告）
+- [x] バンドルサイズ削減 — `manualChunks` でベンダーチャンク分離 + `isReadOnlyTool` 依存切断 + `React.lazy()` で SettingsModal 遅延ロード（950KB → 全チャンク 500KB 未満）
 
 ### オフライン対応
 - [ ] Service Worker キャッシュ戦略の改善

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,10 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, lazy, Suspense } from 'react';
 import { ChatView } from './components/ChatView';
 import { ConversationSidebar } from './components/ConversationSidebar';
 import { HeartbeatPanel } from './components/HeartbeatPanel';
-import { SettingsModal } from './components/SettingsModal';
+const SettingsModal = lazy(() =>
+  import('./components/SettingsModal').then((m) => ({ default: m.SettingsModal }))
+);
 import { useAgentChat } from './hooks/useAgentChat';
 import { useConversations } from './hooks/useConversations';
 import { useHeartbeat } from './hooks/useHeartbeat';
@@ -194,7 +196,9 @@ export default function App() {
             onStop={stopStreaming}
           />
         </main>
-        <SettingsModal open={settingsOpen} onClose={handleSettingsClose} />
+        <Suspense fallback={null}>
+          <SettingsModal open={settingsOpen} onClose={handleSettingsClose} />
+        </Suspense>
       </div>
     </div>
   );

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -62,8 +62,8 @@ vi.mock('../core/corsProxy', () => ({
   registerProxyToken: vi.fn(async () => 'mock-token'),
 }));
 
-// agent モック（isReadOnlyTool）
-vi.mock('../core/agent', () => ({
+// toolUtils モック（isReadOnlyTool）
+vi.mock('../core/toolUtils', () => ({
   isReadOnlyTool: vi.fn((name: string) => {
     const prefixes = ['list_', 'get_', 'search_', 'read_'];
     return prefixes.some((p) => name.startsWith(p));

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -5,7 +5,7 @@ import { getNotificationPermission, requestNotificationPermission } from '../cor
 import { subscribePush, unsubscribePush, getPushSubscription, registerPeriodicSync, unregisterPeriodicSync } from '../core/pushSubscription';
 import { registerProxyToken } from '../core/corsProxy';
 import { getUrlValidationError } from '../core/urlValidation';
-import { isReadOnlyTool } from '../core/agent';
+import { isReadOnlyTool } from '../core/toolUtils';
 import type { AppConfig, MCPServerConfig, HeartbeatConfig, HeartbeatTask, TaskSchedule, OtelConfig, PushConfig, ProxyConfig, PersonaConfig } from '../types';
 
 interface Props {

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -30,13 +30,8 @@ export async function createAgent(mcpServers?: MCPServer[]): Promise<Agent> {
   });
 }
 
-/** read-only ツール判定用プレフィックス */
-const READ_ONLY_PREFIXES = ['list_', 'get_', 'search_', 'read_'];
-
-/** ツール名が read-only かどうか判定する */
-export function isReadOnlyTool(name: string): boolean {
-  return READ_ONLY_PREFIXES.some((p) => name.startsWith(p));
-}
+// 後方互換の re-export
+export { isReadOnlyTool } from './toolUtils';
 
 export async function createHeartbeatAgent(
   mcpServers?: MCPServer[],

--- a/src/core/toolUtils.ts
+++ b/src/core/toolUtils.ts
@@ -1,0 +1,7 @@
+/** read-only ツール判定用プレフィックス */
+const READ_ONLY_PREFIXES = ['list_', 'get_', 'search_', 'read_'];
+
+/** ツール名が read-only かどうか判定する */
+export function isReadOnlyTool(name: string): boolean {
+  return READ_ONLY_PREFIXES.some((p) => name.startsWith(p));
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,6 +43,29 @@ export default defineConfig({
       },
     }),
   ],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('node_modules/react-dom/') || id.includes('node_modules/react/')) {
+            return 'vendor-react';
+          }
+          if (id.includes('node_modules/@openai/') || id.includes('node_modules/openai/')) {
+            return 'vendor-agent';
+          }
+          if (id.includes('node_modules/@modelcontextprotocol/')) {
+            return 'vendor-mcp';
+          }
+          if (id.includes('node_modules/zod/')) {
+            return 'vendor-zod';
+          }
+          if (id.includes('node_modules/marked/') || id.includes('node_modules/dompurify/')) {
+            return 'vendor-markdown';
+          }
+        },
+      },
+    },
+  },
   server: {
     proxy: {
       '/api/brave': {


### PR DESCRIPTION
## Summary
- `isReadOnlyTool` を `toolUtils.ts` に抽出し、`SettingsModal` → `agent.ts` → `@openai/agents` の依存連鎖を切断
- `vite.config.ts` に `manualChunks` 関数を追加し、ベンダーライブラリを5つの独立チャンクに分割（react, agent, mcp, zod, markdown）
- `SettingsModal` を `React.lazy()` + `Suspense` で遅延ロードし、初期ロードから分離
- メインバンドル 950KB → 全チャンク 500KB 未満（最大 327KB: vendor-agent）で Vite 警告を解消

## Chunk breakdown
| チャンク | サイズ |
|---|---|
| `vendor-agent` | 327 KB |
| `vendor-mcp` | 196 KB |
| `vendor-react` | 192 KB |
| `vendor-zod` | 78 KB |
| `index` (アプリコード) | 75 KB |
| `vendor-markdown` | 64 KB |
| `SettingsModal` (lazy) | 17 KB |

## Test plan
- [x] `npm test` — 422 テスト全通過
- [x] `npm run build` — 500KB 超過チャンクなし、Vite 警告なし
- [ ] `npm run preview` — ページロード → チャット → 設定モーダルの手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)