### PR TITLE
feat: 認知的記憶アーキテクチャ Phase E — 指数減衰・重複排除・ふりかえり

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,7 +23,7 @@
 - Heartbeat 3層構成（メインスレッド + Dedicated Worker + Service Worker/Push）
 - CORS プロキシ（Cloudflare Workers 拡張 — トークン認証 + SSRF 防止 + レート制限）
 - セキュリティ基盤（CSP ヘッダー + URL HTTPS 強制バリデーション）
-- テスト 422 件
+- テスト 448 件
 
 ---
 
@@ -162,6 +162,17 @@
 - [x] Integration — agent.ts/heartbeatOpenAI.ts/heartbeatCommon.ts に persona + instructionBuilder 統合
 - [x] DB_VERSION 8→9（memories ストアに importance/tags インデックス追加）
 - [ ] ペルソナプリセット配布 + インポート機能
+
+### 認知的記憶アーキテクチャ（Phase E）
+- [x] 指数減衰スコアリング — カテゴリ別半減期（personality:1年 〜 other:2週間）+ アクセス頻度ブースト
+- [x] コンテンツハッシュ重複排除 — SHA-256 ハッシュで同一内容の記憶を統合（importance 最大値採用 + tags マージ）
+- [x] 品質ベースアーカイブ — FIFO 削除を廃止、最低スコア記憶を memories_archive に移動（personality/routine は保護）
+- [x] Memory モデル拡張 — accessCount/lastAccessedAt/contentHash フィールド追加 + ArchivedMemory 型
+- [x] DB_VERSION 9→10（contentHash/lastAccessedAt インデックス + memories_archive ストア）
+- [x] ふりかえりタスク — reflection ビルトインタスク（23:00 固定スケジュール）+ Worker ツール 3 種（getRecentMemoriesForReflection/saveReflection/cleanupMemories）
+- [x] reflection カテゴリ — MemoryCategory に追加 + instructionBuilder で「振り返りからの洞察」分離表示
+- [ ] ふりかえり UI — reflection 記憶の閲覧・管理画面
+- [ ] アーカイブ閲覧 UI — memories_archive の参照・復元機能
 
 ### エージェント自律性強化
 - [ ] 情報収集ワークフロー（RSS ダイジェスト、ニュースブリーフィング等の Heartbeat タスク）

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -106,6 +106,41 @@ describe('getConfig / saveConfig', () => {
     expect(config.heartbeat!.intervalMinutes).toBe(15);
     expect(config.heartbeat!.desktopNotification).toBe(false);
   });
+
+  it('保存済み tasks に不足しているビルトインタスクが自動追加される', () => {
+    const oldTasks = [
+      { id: 'calendar-check', name: 'カレンダーチェック', description: '', enabled: true, type: 'builtin' as const },
+    ];
+    localStorage.setItem('iagent-config', JSON.stringify({
+      openaiApiKey: 'sk-test',
+      heartbeat: { enabled: true, tasks: oldTasks },
+    }));
+    const config = getConfig();
+    const taskIds = config.heartbeat!.tasks.map((t) => t.id);
+    // 既存タスクは維持
+    expect(taskIds).toContain('calendar-check');
+    // 不足しているビルトインタスクが追加
+    for (const builtin of BUILTIN_HEARTBEAT_TASKS) {
+      expect(taskIds).toContain(builtin.id);
+    }
+    // 既存タスクの設定は上書きされない
+    const cal = config.heartbeat!.tasks.find((t) => t.id === 'calendar-check');
+    expect(cal!.enabled).toBe(true);
+  });
+
+  it('全ビルトインタスクが揃っている場合は重複追加されない', () => {
+    const config1: AppConfig = {
+      openaiApiKey: 'sk-test',
+      braveApiKey: '',
+      openWeatherMapApiKey: '',
+      mcpServers: [],
+      heartbeat: getDefaultHeartbeatConfig(),
+    };
+    saveConfig(config1);
+    const loaded = getConfig();
+    const builtinCount = loaded.heartbeat!.tasks.filter((t) => t.type === 'builtin').length;
+    expect(builtinCount).toBe(BUILTIN_HEARTBEAT_TASKS.length);
+  });
 });
 
 describe('getConfigValue', () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -32,6 +32,14 @@ export const BUILTIN_HEARTBEAT_TASKS: HeartbeatTask[] = [
     enabled: false,
     type: 'builtin',
   },
+  {
+    id: 'reflection',
+    name: 'ふりかえり',
+    description: '1日の記憶を振り返り、パターンや洞察を抽出して長期記憶に保存します。',
+    enabled: false,
+    type: 'builtin',
+    schedule: { type: 'fixed-time', hour: 23, minute: 0 },
+  },
 ];
 
 export function getDefaultProxyConfig(): ProxyConfig {
@@ -73,20 +81,32 @@ export function getDefaultHeartbeatConfig(): HeartbeatConfig {
   };
 }
 
+/** 保存済み tasks に不足しているビルトインタスクを追加する */
+function mergeBuiltinTasks(savedTasks: HeartbeatTask[]): HeartbeatTask[] {
+  const existingIds = new Set(savedTasks.map((t) => t.id));
+  const missing = BUILTIN_HEARTBEAT_TASKS
+    .filter((b) => !existingIds.has(b.id))
+    .map((t) => ({ ...t }));
+  return [...savedTasks, ...missing];
+}
+
 export function getConfig(): AppConfig {
   const raw = localStorage.getItem(STORAGE_KEY);
   if (!raw) {
     return { openaiApiKey: '', braveApiKey: '', openWeatherMapApiKey: '', mcpServers: [], heartbeat: getDefaultHeartbeatConfig(), push: { enabled: false, serverUrl: '' }, proxy: getDefaultProxyConfig(), otel: getDefaultOtelConfig(), persona: getDefaultPersonaConfig() };
   }
   const parsed = JSON.parse(raw) as Partial<AppConfig>;
+  const heartbeat = parsed.heartbeat
+    ? { ...getDefaultHeartbeatConfig(), ...parsed.heartbeat }
+    : getDefaultHeartbeatConfig();
+  // 不足しているビルトインタスクを補完
+  heartbeat.tasks = mergeBuiltinTasks(heartbeat.tasks);
   return {
     openaiApiKey: parsed.openaiApiKey ?? '',
     braveApiKey: parsed.braveApiKey ?? '',
     openWeatherMapApiKey: parsed.openWeatherMapApiKey ?? '',
     mcpServers: parsed.mcpServers ?? [],
-    heartbeat: parsed.heartbeat
-      ? { ...getDefaultHeartbeatConfig(), ...parsed.heartbeat }
-      : getDefaultHeartbeatConfig(),
+    heartbeat,
     push: parsed.push ?? { enabled: false, serverUrl: '' },
     proxy: parsed.proxy
       ? { ...getDefaultProxyConfig(), ...parsed.proxy }

--- a/src/core/heartbeatTools.test.ts
+++ b/src/core/heartbeatTools.test.ts
@@ -5,6 +5,7 @@ vi.mock('../store/db');
 
 import { WORKER_TOOLS, executeWorkerTool } from './heartbeatTools';
 import { getDB } from '../store/db';
+import { saveMemory } from '../store/memoryStore';
 
 beforeEach(() => {
   __resetStores();
@@ -12,13 +13,16 @@ beforeEach(() => {
 
 describe('WORKER_TOOLS', () => {
   it('全 Worker ツールが定義されている', () => {
-    expect(WORKER_TOOLS).toHaveLength(5);
+    expect(WORKER_TOOLS).toHaveLength(8);
     const names = WORKER_TOOLS.map((t) => t.function.name);
     expect(names).toContain('listCalendarEvents');
     expect(names).toContain('getCurrentTime');
     expect(names).toContain('fetchFeeds');
     expect(names).toContain('listFeeds');
     expect(names).toContain('checkMonitors');
+    expect(names).toContain('getRecentMemoriesForReflection');
+    expect(names).toContain('saveReflection');
+    expect(names).toContain('cleanupMemories');
   });
 
   it('全ツールが function タイプである', () => {
@@ -76,6 +80,75 @@ describe('executeWorkerTool', () => {
       const parsed = JSON.parse(result);
       expect(parsed.currentTime).toBeDefined();
       expect(typeof parsed.currentTime).toBe('string');
+    });
+  });
+
+  describe('getRecentMemoriesForReflection', () => {
+    it('直近の記憶とアクセス上位を返す', async () => {
+      await saveMemory('最近のメモリ', 'fact');
+      await saveMemory('もう一つの記憶', 'preference');
+
+      const result = await executeWorkerTool('getRecentMemoriesForReflection', {});
+      const parsed = JSON.parse(result);
+      expect(parsed.recentCount).toBe(2);
+      expect(parsed.topAccessedCount).toBe(2);
+      expect(parsed.recent).toHaveLength(2);
+      expect(parsed.topAccessed).toHaveLength(2);
+    });
+
+    it('記憶なしでも正常に動作する', async () => {
+      const result = await executeWorkerTool('getRecentMemoriesForReflection', {});
+      const parsed = JSON.parse(result);
+      expect(parsed.recentCount).toBe(0);
+      expect(parsed.topAccessedCount).toBe(0);
+    });
+  });
+
+  describe('saveReflection', () => {
+    it('ふりかえりを reflection カテゴリで保存する', async () => {
+      const result = await executeWorkerTool('saveReflection', {
+        content: 'ユーザーは朝型で、午前中の作業効率が高い',
+        importance: 4,
+        tags: '洞察,パターン',
+      });
+      const parsed = JSON.parse(result);
+      expect(parsed.message).toBe('ふりかえりを保存しました');
+      expect(parsed.memory.category).toBe('reflection');
+      expect(parsed.memory.importance).toBe(4);
+      expect(parsed.memory.tags).toEqual(['洞察', 'パターン']);
+    });
+
+    it('content なしでエラーを返す', async () => {
+      const result = await executeWorkerTool('saveReflection', {});
+      const parsed = JSON.parse(result);
+      expect(parsed.error).toBe('content は必須です');
+    });
+
+    it('デフォルト importance は 3', async () => {
+      const result = await executeWorkerTool('saveReflection', {
+        content: 'シンプルな振り返り',
+      });
+      const parsed = JSON.parse(result);
+      expect(parsed.memory.importance).toBe(3);
+    });
+  });
+
+  describe('cleanupMemories', () => {
+    it('低スコア記憶をアーカイブする', async () => {
+      for (let i = 0; i < 10; i++) {
+        await saveMemory(`メモリ ${i}`, 'other');
+      }
+
+      const result = await executeWorkerTool('cleanupMemories', {});
+      const parsed = JSON.parse(result);
+      expect(parsed.archivedCount).toBe(5);
+      expect(parsed.message).toContain('5 件');
+    });
+
+    it('記憶なしでもエラーにならない', async () => {
+      const result = await executeWorkerTool('cleanupMemories', {});
+      const parsed = JSON.parse(result);
+      expect(parsed.archivedCount).toBe(0);
     });
   });
 

--- a/src/core/heartbeatTools.ts
+++ b/src/core/heartbeatTools.ts
@@ -3,6 +3,7 @@ import type { CalendarEvent, Feed, FeedItem, Monitor } from '../types';
 import { loadConfigFromIDB } from '../store/configStore';
 import { parseFeed } from './feedParser';
 import { fetchViaProxy } from './corsProxy';
+import { saveMemory, getRecentMemoriesForReflection, cleanupLowScoredMemories } from '../store/memoryStore';
 
 /** OpenAI function calling 形式のツールスキーマ */
 export const WORKER_TOOLS = [
@@ -60,6 +61,44 @@ export const WORKER_TOOLS = [
     function: {
       name: 'checkMonitors',
       description: '監視中の全 Web ページの変更をチェックします。',
+      parameters: {
+        type: 'object',
+        properties: {},
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'getRecentMemoriesForReflection',
+      description: '直近24時間の記憶と、よく参照される記憶を取得します。',
+      parameters: {
+        type: 'object',
+        properties: {},
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'saveReflection',
+      description: 'ふりかえりの結果を reflection カテゴリの長期記憶として保存します。',
+      parameters: {
+        type: 'object',
+        properties: {
+          content: { type: 'string', description: 'ふりかえりの内容' },
+          tags: { type: 'string', description: 'タグ（カンマ区切り）' },
+          importance: { type: 'number', description: '重要度（1-5）' },
+        },
+        required: ['content'],
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'cleanupMemories',
+      description: '低スコアの記憶をアーカイブに移動します。',
       parameters: {
         type: 'object',
         properties: {},
@@ -237,6 +276,52 @@ export async function executeWorkerTool(
       }
 
       return JSON.stringify({ results, totalMonitors: monitors.length });
+    }
+    case 'getRecentMemoriesForReflection': {
+      const { recent, topAccessed } = await getRecentMemoriesForReflection();
+      return JSON.stringify({
+        recent: recent.map((m) => ({
+          id: m.id,
+          content: m.content,
+          category: m.category,
+          importance: m.importance,
+          tags: m.tags,
+          accessCount: m.accessCount,
+          updatedAt: m.updatedAt,
+        })),
+        topAccessed: topAccessed.map((m) => ({
+          id: m.id,
+          content: m.content,
+          category: m.category,
+          importance: m.importance,
+          tags: m.tags,
+          accessCount: m.accessCount,
+          updatedAt: m.updatedAt,
+        })),
+        recentCount: recent.length,
+        topAccessedCount: topAccessed.length,
+      });
+    }
+    case 'saveReflection': {
+      const content = args.content as string;
+      if (!content) {
+        return JSON.stringify({ error: 'content は必須です' });
+      }
+      const importance = typeof args.importance === 'number'
+        ? Math.max(1, Math.min(5, args.importance))
+        : 3;
+      const tags = typeof args.tags === 'string'
+        ? args.tags.split(',').map((t: string) => t.trim()).filter((t: string) => t.length > 0)
+        : [];
+      const memory = await saveMemory(content, 'reflection', { importance, tags });
+      return JSON.stringify({ message: 'ふりかえりを保存しました', memory });
+    }
+    case 'cleanupMemories': {
+      const archivedCount = await cleanupLowScoredMemories(5);
+      return JSON.stringify({
+        message: `${archivedCount} 件の記憶をアーカイブしました`,
+        archivedCount,
+      });
     }
     default:
       return JSON.stringify({ error: `不明なツール: ${name}` });

--- a/src/core/instructionBuilder.test.ts
+++ b/src/core/instructionBuilder.test.ts
@@ -22,6 +22,9 @@ function makeMemory(overrides?: Partial<Memory>): Memory {
     tags: [],
     createdAt: Date.now(),
     updatedAt: Date.now(),
+    accessCount: 0,
+    lastAccessedAt: Date.now(),
+    contentHash: '',
     ...overrides,
   };
 }
@@ -90,6 +93,7 @@ describe('buildMainInstructions', () => {
     expect(result).toContain('routine');
     expect(result).toContain('goal');
     expect(result).toContain('personality');
+    expect(result).toContain('reflection');
   });
 
   it('プロアクティブ行動を含む', () => {
@@ -97,7 +101,7 @@ describe('buildMainInstructions', () => {
     expect(result).toContain('プロアクティブ行動');
   });
 
-  it('メモリコンテキストを含む', () => {
+  it('通常メモリコンテキストを含む', () => {
     const memories = [
       makeMemory({ content: 'ユーザーは東京在住', category: 'fact' }),
       makeMemory({ id: 'mem-2', content: '朝7時に起床', category: 'routine' }),
@@ -108,9 +112,31 @@ describe('buildMainInstructions', () => {
     expect(result).toContain('[routine] 朝7時に起床');
   });
 
+  it('reflection メモリは「振り返りからの洞察」セクションに分離表示される', () => {
+    const memories = [
+      makeMemory({ content: '通常のメモリ', category: 'fact' }),
+      makeMemory({ id: 'mem-2', content: 'ユーザーは朝型', category: 'reflection' }),
+    ];
+    const result = buildMainInstructions(makeContext({ memories }));
+    expect(result).toContain('あなたの記憶');
+    expect(result).toContain('[fact] 通常のメモリ');
+    expect(result).toContain('振り返りからの洞察');
+    expect(result).toContain('[reflection] ユーザーは朝型');
+  });
+
+  it('reflection のみの場合は「あなたの記憶」セクションが含まれない', () => {
+    const memories = [
+      makeMemory({ content: '洞察のみ', category: 'reflection' }),
+    ];
+    const result = buildMainInstructions(makeContext({ memories }));
+    expect(result).not.toContain('あなたの記憶');
+    expect(result).toContain('振り返りからの洞察');
+  });
+
   it('メモリ 0 件でもエラーにならない', () => {
     const result = buildMainInstructions(makeContext({ memories: [] }));
     expect(result).not.toContain('あなたの記憶');
+    expect(result).not.toContain('振り返りからの洞察');
   });
 
   it('importance が 3 以外の場合に表示される', () => {
@@ -166,16 +192,29 @@ describe('buildHeartbeatInstructions', () => {
     expect(result).toContain('冷静沈着');
   });
 
-  it('メモリコンテキストを含む', () => {
+  it('通常メモリコンテキストを含む', () => {
     const memories = [makeMemory({ content: 'テストメモリ', category: 'preference' })];
     const result = buildHeartbeatInstructions(makeContext({ memories }));
     expect(result).toContain('ユーザーについての記憶');
     expect(result).toContain('[preference] テストメモリ');
   });
 
+  it('reflection メモリは「振り返りからの洞察」に分離表示される', () => {
+    const memories = [
+      makeMemory({ content: '通常メモリ', category: 'fact' }),
+      makeMemory({ id: 'mem-2', content: 'パターン発見', category: 'reflection' }),
+    ];
+    const result = buildHeartbeatInstructions(makeContext({ memories }));
+    expect(result).toContain('ユーザーについての記憶');
+    expect(result).toContain('[fact] 通常メモリ');
+    expect(result).toContain('振り返りからの洞察');
+    expect(result).toContain('[reflection] パターン発見');
+  });
+
   it('メモリ 0 件でも正常', () => {
     const result = buildHeartbeatInstructions(makeContext({ memories: [] }));
     expect(result).not.toContain('ユーザーについての記憶');
+    expect(result).not.toContain('振り返りからの洞察');
   });
 });
 

--- a/src/core/instructionBuilder.ts
+++ b/src/core/instructionBuilder.ts
@@ -49,6 +49,7 @@ export function buildMainInstructions(ctx: InstructionContext): string {
 - routine: ユーザーの日課・習慣
 - goal: ユーザーの目標・締切
 - personality: エージェントの振る舞い指示
+- reflection: 振り返りで得た洞察やパターン
 
 **重要度（importance 1-5）**:
 - 5: 絶対に忘れてはいけない情報（名前、重要な締切等）
@@ -69,8 +70,13 @@ export function buildMainInstructions(ctx: InstructionContext): string {
 
   // 6. コンテキスト
   const contextParts: string[] = [`## コンテキスト\n現在の日時: ${ctx.currentDateTime}`];
-  if (ctx.memories.length > 0) {
-    contextParts.push(`\n### あなたの記憶\n以下はこれまでに保存した重要な情報です:\n${formatMemories(ctx.memories)}`);
+  const regularMemories = ctx.memories.filter((m) => m.category !== 'reflection');
+  const reflections = ctx.memories.filter((m) => m.category === 'reflection');
+  if (regularMemories.length > 0) {
+    contextParts.push(`\n### あなたの記憶\n以下はこれまでに保存した重要な情報です:\n${formatMemories(regularMemories)}`);
+  }
+  if (reflections.length > 0) {
+    contextParts.push(`\n### 振り返りからの洞察\n${formatMemories(reflections)}`);
   }
   sections.push(contextParts.join(''));
 
@@ -109,8 +115,13 @@ export function buildHeartbeatInstructions(ctx: InstructionContext): string {
 - 日本語で summary を書いてください`);
 
   // メモリ
-  if (ctx.memories.length > 0) {
-    sections.push(`ユーザーについての記憶:\n${formatMemories(ctx.memories)}`);
+  const hbRegularMemories = ctx.memories.filter((m) => m.category !== 'reflection');
+  const hbReflections = ctx.memories.filter((m) => m.category === 'reflection');
+  if (hbRegularMemories.length > 0) {
+    sections.push(`ユーザーについての記憶:\n${formatMemories(hbRegularMemories)}`);
+  }
+  if (hbReflections.length > 0) {
+    sections.push(`振り返りからの洞察:\n${formatMemories(hbReflections)}`);
   }
 
   return sections.join('\n\n');

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -1,7 +1,7 @@
 import { openDB, type IDBPDatabase } from 'idb';
 
 const DB_NAME = 'iagent-db';
-const DB_VERSION = 9;
+const DB_VERSION = 10;
 
 let dbPromise: Promise<IDBPDatabase> | null = null;
 
@@ -63,6 +63,22 @@ export function getDB(): Promise<IDBPDatabase> {
           if (!memStore.indexNames.contains('tags')) {
             memStore.createIndex('tags', 'tags', { unique: false, multiEntry: true });
           }
+        }
+        // Phase E: memories ストアに contentHash/lastAccessedAt インデックス追加
+        if (db.objectStoreNames.contains('memories')) {
+          const memStoreE = transaction.objectStore('memories');
+          if (!memStoreE.indexNames.contains('contentHash')) {
+            memStoreE.createIndex('contentHash', 'contentHash', { unique: false });
+          }
+          if (!memStoreE.indexNames.contains('lastAccessedAt')) {
+            memStoreE.createIndex('lastAccessedAt', 'lastAccessedAt', { unique: false });
+          }
+        }
+        // Phase E: memories_archive ストア新規作成
+        if (!db.objectStoreNames.contains('memories_archive')) {
+          const archiveStore = db.createObjectStore('memories_archive', { keyPath: 'id' });
+          archiveStore.createIndex('archivedAt', 'archivedAt', { unique: false });
+          archiveStore.createIndex('category', 'category', { unique: false });
         }
         // conversations ストアに conversationId インデックス追加
         if (db.objectStoreNames.contains('conversations')) {

--- a/src/store/memoryStore.test.ts
+++ b/src/store/memoryStore.test.ts
@@ -11,7 +11,13 @@ import {
   getRecentMemories,
   getRelevantMemories,
   normalizeMemory,
+  scoreMemory,
+  computeContentHash,
+  getRecentMemoriesForReflection,
+  cleanupLowScoredMemories,
+  HALF_LIFE_MS,
 } from './memoryStore';
+import type { Memory } from '../types';
 
 beforeEach(() => {
   __resetStores();
@@ -31,6 +37,99 @@ describe('normalizeMemory', () => {
     expect(normalized.importance).toBe(5);
     expect(normalized.tags).toEqual(['a']);
   });
+
+  it('新フィールド（accessCount, lastAccessedAt, contentHash）のデフォルト値', () => {
+    const raw = { id: '1', content: 'test', category: 'fact', createdAt: 100, updatedAt: 200 };
+    const normalized = normalizeMemory(raw);
+    expect(normalized.accessCount).toBe(0);
+    expect(normalized.lastAccessedAt).toBe(200); // updatedAt にフォールバック
+    expect(normalized.contentHash).toBe('');
+  });
+
+  it('新フィールドが設定済みの場合はそのまま返す', () => {
+    const raw = {
+      id: '1', content: 'test', category: 'fact',
+      createdAt: 100, updatedAt: 200,
+      accessCount: 5, lastAccessedAt: 300, contentHash: 'abc123',
+    };
+    const normalized = normalizeMemory(raw);
+    expect(normalized.accessCount).toBe(5);
+    expect(normalized.lastAccessedAt).toBe(300);
+    expect(normalized.contentHash).toBe('abc123');
+  });
+});
+
+describe('computeContentHash', () => {
+  it('同じ内容に対して同じハッシュを返す', async () => {
+    const hash1 = await computeContentHash('テストコンテンツ');
+    const hash2 = await computeContentHash('テストコンテンツ');
+    expect(hash1).toBe(hash2);
+    expect(hash1).toHaveLength(64); // SHA-256 hex = 64 chars
+  });
+
+  it('異なる内容に対して異なるハッシュを返す', async () => {
+    const hash1 = await computeContentHash('コンテンツA');
+    const hash2 = await computeContentHash('コンテンツB');
+    expect(hash1).not.toBe(hash2);
+  });
+});
+
+describe('scoreMemory', () => {
+  const now = Date.now();
+
+  function makeMemory(overrides?: Partial<Memory>): Memory {
+    return {
+      id: '1',
+      content: 'テスト',
+      category: 'fact',
+      importance: 3,
+      tags: [],
+      createdAt: now,
+      updatedAt: now,
+      accessCount: 0,
+      lastAccessedAt: now,
+      contentHash: '',
+      ...overrides,
+    };
+  }
+
+  it('最新の記憶は最大減衰スコア（+3）を得る', () => {
+    const m = makeMemory({ updatedAt: now });
+    const score = scoreMemory(m, now);
+    // importance(3) + categoryBonus(fact=1) + decay(3) + accessBoost(×1)
+    expect(score).toBeCloseTo(7, 0);
+  });
+
+  it('半減期経過時にスコアが半減する', () => {
+    const halfLife = HALF_LIFE_MS.fact; // 60日
+    const fresh = makeMemory({ updatedAt: now });
+    const aged = makeMemory({ updatedAt: now - halfLife });
+
+    const freshScore = scoreMemory(fresh, now);
+    const agedScore = scoreMemory(aged, now);
+
+    // 減衰部分が半分になる → fresh は +3、aged は +1.5
+    const decayDiff = freshScore - agedScore;
+    expect(decayDiff).toBeCloseTo(1.5, 1);
+  });
+
+  it('personality カテゴリは最大カテゴリボーナスを得る', () => {
+    const personality = makeMemory({ category: 'personality' });
+    const other = makeMemory({ category: 'other' });
+    expect(scoreMemory(personality, now)).toBeGreaterThan(scoreMemory(other, now));
+  });
+
+  it('accessCount が高いとスコアがブーストされる', () => {
+    const low = makeMemory({ accessCount: 0 });
+    const high = makeMemory({ accessCount: 10 });
+    expect(scoreMemory(high, now)).toBeGreaterThan(scoreMemory(low, now));
+  });
+
+  it('accessCount ブーストは 10 で上限', () => {
+    const ten = makeMemory({ accessCount: 10 });
+    const twenty = makeMemory({ accessCount: 20 });
+    expect(scoreMemory(ten, now)).toBe(scoreMemory(twenty, now));
+  });
 });
 
 describe('saveMemory', () => {
@@ -43,6 +142,9 @@ describe('saveMemory', () => {
     expect(memory.tags).toEqual([]);
     expect(memory.createdAt).toBeGreaterThan(0);
     expect(memory.updatedAt).toBe(memory.createdAt);
+    expect(memory.accessCount).toBe(0);
+    expect(memory.lastAccessedAt).toBe(memory.createdAt);
+    expect(memory.contentHash).toHaveLength(64);
   });
 
   it('importance を指定して保存できる', async () => {
@@ -72,7 +174,7 @@ describe('saveMemory', () => {
     expect(memory.tags).toEqual([]);
   });
 
-  it('新カテゴリ（routine, goal, personality）で保存できる', async () => {
+  it('新カテゴリ（routine, goal, personality, reflection）で保存できる', async () => {
     const routine = await saveMemory('毎朝7時にニュース確認', 'routine');
     expect(routine.category).toBe('routine');
 
@@ -81,11 +183,30 @@ describe('saveMemory', () => {
 
     const personality = await saveMemory('敬語で話して', 'personality');
     expect(personality.category).toBe('personality');
+
+    const reflection = await saveMemory('ユーザーは朝方に活発', 'reflection');
+    expect(reflection.category).toBe('reflection');
   });
 
-  it('MAX_MEMORIES を超えたとき最古が削除される', async () => {
-    // 100件保存
-    for (let i = 0; i < 100; i++) {
+  it('同一コンテンツの重複保存時は既存メモリを更新する', async () => {
+    const first = await saveMemory('同じ内容です', 'fact', { importance: 2, tags: ['a'] });
+    const second = await saveMemory('同じ内容です', 'fact', { importance: 4, tags: ['b'] });
+
+    // 同じ ID が返る
+    expect(second.id).toBe(first.id);
+    // importance は最大値を採用
+    expect(second.importance).toBe(4);
+    // tags はマージされる
+    expect(second.tags).toEqual(expect.arrayContaining(['a', 'b']));
+
+    // DB 上は 1 件のみ
+    const all = await listMemories();
+    expect(all).toHaveLength(1);
+  });
+
+  it('MAX_MEMORIES を超えたとき低スコアの記憶がアーカイブされる', async () => {
+    // 200件保存
+    for (let i = 0; i < 200; i++) {
       const m = await saveMemory(`メモリ ${i}`, 'other');
       // updatedAt を手動で設定して順序を保証
       const db = (await import('./__mocks__/db')).getDB;
@@ -98,12 +219,12 @@ describe('saveMemory', () => {
     }
 
     const before = await listMemories();
-    expect(before).toHaveLength(100);
+    expect(before).toHaveLength(200);
 
-    // 101件目を保存 → 最古が削除される
+    // 201件目を保存 → 低スコアがアーカイブされる
     await saveMemory('新しいメモリ', 'other');
     const after = await listMemories();
-    expect(after).toHaveLength(100);
+    expect(after).toHaveLength(200);
     expect(after.find((m) => m.content === '新しいメモリ')).toBeDefined();
   });
 });
@@ -267,7 +388,77 @@ describe('getRelevantMemories', () => {
     await saveMemory('メモリB', 'fact', { importance: 1 });
 
     const results = await getRelevantMemories('', 2);
-    // preference(+2) + importance(5) = 7 > fact(+1) + importance(1) = 2
+    // preference(+2) + importance(5) > fact(+1) + importance(1)
     expect(results[0].content).toBe('メモリA');
+  });
+});
+
+describe('getRecentMemoriesForReflection', () => {
+  it('直近24時間の記憶を取得する', async () => {
+    const m1 = await saveMemory('最近のメモリ', 'fact');
+    const m2 = await saveMemory('古いメモリ', 'fact');
+
+    // m2 を 2 日前に設定
+    const { getDB: db } = await import('./__mocks__/db');
+    const mockDb = await db();
+    const stored = await mockDb.get('memories', m2.id);
+    if (stored) {
+      stored.updatedAt = Date.now() - 2 * 24 * 60 * 60 * 1000;
+      await mockDb.put('memories', stored);
+    }
+
+    const { recent, topAccessed } = await getRecentMemoriesForReflection();
+    expect(recent.find((r) => r.id === m1.id)).toBeDefined();
+    expect(recent.find((r) => r.id === m2.id)).toBeUndefined();
+    expect(topAccessed).toHaveLength(2); // 全 2 件
+  });
+
+  it('アクセス上位 10 件を返す', async () => {
+    for (let i = 0; i < 15; i++) {
+      const m = await saveMemory(`メモリ ${i}`, 'fact');
+      // accessCount を手動設定
+      const { getDB: db } = await import('./__mocks__/db');
+      const mockDb = await db();
+      const stored = await mockDb.get('memories', m.id);
+      if (stored) {
+        stored.accessCount = i;
+        await mockDb.put('memories', stored);
+      }
+    }
+
+    const { topAccessed } = await getRecentMemoriesForReflection();
+    expect(topAccessed).toHaveLength(10);
+    // 降順ソート
+    expect(topAccessed[0].accessCount).toBeGreaterThanOrEqual(topAccessed[9].accessCount);
+  });
+});
+
+describe('cleanupLowScoredMemories', () => {
+  it('指定件数分の低スコア記憶をアーカイブする', async () => {
+    for (let i = 0; i < 10; i++) {
+      await saveMemory(`メモリ ${i}`, 'other');
+    }
+
+    const before = await listMemories();
+    expect(before).toHaveLength(10);
+
+    const archived = await cleanupLowScoredMemories(3);
+    expect(archived).toBe(3);
+
+    const after = await listMemories();
+    expect(after).toHaveLength(7);
+  });
+
+  it('personality と routine はアーカイブされない', async () => {
+    await saveMemory('性格情報', 'personality');
+    await saveMemory('日課情報', 'routine');
+    await saveMemory('その他', 'other');
+
+    const archived = await cleanupLowScoredMemories(2);
+    expect(archived).toBe(1); // other のみアーカイブ
+
+    const after = await listMemories();
+    expect(after).toHaveLength(2);
+    expect(after.map((m) => m.category)).toEqual(expect.arrayContaining(['personality', 'routine']));
   });
 });

--- a/src/store/memoryStore.ts
+++ b/src/store/memoryStore.ts
@@ -1,17 +1,124 @@
 import { getDB } from './db';
-import type { Memory, MemoryCategory } from '../types';
+import type { Memory, MemoryCategory, ArchivedMemory } from '../types';
 
 const STORE_NAME = 'memories';
-const MAX_MEMORIES = 100;
+const ARCHIVE_STORE_NAME = 'memories_archive';
+const MAX_MEMORIES = 200;
 
-/** 既存データの後方互換: importance/tags が未設定の場合にフォールバック */
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** カテゴリ別半減期（ミリ秒） */
+export const HALF_LIFE_MS: Record<MemoryCategory, number> = {
+  personality: 365 * DAY_MS,   // 1年
+  routine:     180 * DAY_MS,   // 6ヶ月
+  goal:        120 * DAY_MS,   // 4ヶ月
+  preference:   90 * DAY_MS,   // 3ヶ月
+  reflection:   90 * DAY_MS,   // 3ヶ月
+  fact:         60 * DAY_MS,   // 2ヶ月
+  context:      30 * DAY_MS,   // 1ヶ月
+  other:        14 * DAY_MS,   // 2週間
+};
+
+/** SHA-256 ハッシュ計算ヘルパー */
+export async function computeContentHash(content: string): Promise<string> {
+  const data = new TextEncoder().encode(content);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/** 指数減衰スコアを計算する共通関数 */
+export function scoreMemory(m: Memory, now: number): number {
+  let score = 0;
+
+  // importance 加算
+  score += m.importance;
+
+  // カテゴリボーナス
+  const categoryBonus: Record<MemoryCategory, number> = {
+    personality: 5,
+    routine: 4,
+    goal: 3,
+    preference: 2,
+    reflection: 2,
+    fact: 1,
+    context: 1,
+    other: 0,
+  };
+  score += categoryBonus[m.category] ?? 0;
+
+  // 指数減衰: decay = exp(-ln2 * age / halfLife)
+  const age = now - m.updatedAt;
+  const halfLife = HALF_LIFE_MS[m.category] ?? HALF_LIFE_MS.other;
+  const decay = Math.exp(-Math.LN2 * age / halfLife);
+  score += decay * 3;  // 最大 +3（最新時）、半減期で +1.5
+
+  // アクセス頻度ブースト（最大 +100%）
+  score *= (1 + 0.1 * Math.min(m.accessCount, 10));
+
+  return score;
+}
+
+/** 既存データの後方互換: importance/tags/accessCount 等が未設定の場合にフォールバック */
 export function normalizeMemory(raw: Partial<Memory> & { id: string; content: string; category: string; createdAt: number; updatedAt: number }): Memory {
   return {
     ...raw,
     category: raw.category as MemoryCategory,
     importance: raw.importance ?? 3,
     tags: raw.tags ?? [],
+    accessCount: raw.accessCount ?? 0,
+    lastAccessedAt: raw.lastAccessedAt ?? raw.updatedAt ?? raw.createdAt,
+    contentHash: raw.contentHash ?? '',
   };
+}
+
+/** アクセスメトリクスを非同期更新 */
+async function updateAccessMetrics(ids: string[]): Promise<void> {
+  const db = await getDB();
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  const store = tx.objectStore(STORE_NAME);
+  const now = Date.now();
+  for (const id of ids) {
+    const m = await store.get(id);
+    if (m) {
+      await store.put({
+        ...m,
+        accessCount: ((m as Record<string, unknown>).accessCount as number ?? 0) + 1,
+        lastAccessedAt: now,
+      });
+    }
+  }
+  await tx.done;
+}
+
+/** 品質ベースのアーカイブ: 最低スコアの記憶を memories_archive に移動 */
+export async function archiveLowestScored(db: Awaited<ReturnType<typeof getDB>>, all: Memory[]): Promise<void> {
+  const now = Date.now();
+  // personality, routine は保護（アーカイブしない）
+  const candidates = all.filter(
+    (m) => m.category !== 'personality' && m.category !== 'routine',
+  );
+  if (candidates.length === 0) return;
+
+  // 減衰スコアで最低スコアの記憶を特定
+  const scored = candidates.map((m) => ({
+    memory: m,
+    score: scoreMemory(m, now),
+  }));
+  scored.sort((a, b) => a.score - b.score);
+  const target = scored[0].memory;
+
+  // memories_archive に移動
+  const archived: ArchivedMemory = {
+    ...normalizeMemory(target),
+    archivedAt: now,
+    archiveReason: 'low-score',
+  };
+  const tx = db.transaction([STORE_NAME, ARCHIVE_STORE_NAME], 'readwrite');
+  await tx.objectStore(ARCHIVE_STORE_NAME).put(archived);
+  await tx.objectStore(STORE_NAME).delete(target.id);
+  await tx.done;
 }
 
 export async function saveMemory(
@@ -22,6 +129,24 @@ export async function saveMemory(
   const db = await getDB();
   const now = Date.now();
   const importance = Math.max(1, Math.min(5, options?.importance ?? 3));
+
+  // コンテンツハッシュを計算
+  const contentHash = await computeContentHash(content);
+
+  // 重複チェック: 同一ハッシュの既存メモリがあれば updatedAt のみ更新
+  const all = await db.getAll(STORE_NAME);
+  const existing = (all as Memory[]).find((m) => m.contentHash === contentHash);
+  if (existing) {
+    const updated: Memory = {
+      ...normalizeMemory(existing),
+      updatedAt: now,
+      importance: Math.max(existing.importance ?? 3, importance),
+      tags: [...new Set([...(existing.tags ?? []), ...(options?.tags ?? [])])],
+    };
+    await db.put(STORE_NAME, updated);
+    return updated;
+  }
+
   const memory: Memory = {
     id: crypto.randomUUID(),
     content,
@@ -30,13 +155,17 @@ export async function saveMemory(
     tags: options?.tags ?? [],
     createdAt: now,
     updatedAt: now,
+    accessCount: 0,
+    lastAccessedAt: now,
+    contentHash,
   };
-  // 上限チェック: 古いものから削除
-  const all = await db.getAll(STORE_NAME);
-  if (all.length >= MAX_MEMORIES) {
-    const oldest = [...all].sort((a, b) => a.updatedAt - b.updatedAt)[0];
-    await db.delete(STORE_NAME, oldest.id);
+
+  // 上限チェック: 品質ベースアーカイブ
+  const normalized = (all as Memory[]).map(normalizeMemory);
+  if (normalized.length >= MAX_MEMORIES) {
+    await archiveLowestScored(db, normalized);
   }
+
   await db.put(STORE_NAME, memory);
   return memory;
 }
@@ -74,28 +203,16 @@ export async function getRecentMemories(limit: number = 10): Promise<Memory[]> {
   return all.slice(0, limit);
 }
 
-/** 関連性ベースの記憶取得 */
+/** 関連性ベースの記憶取得（指数減衰スコアリング） */
 export async function getRelevantMemories(
   query: string,
   limit: number = 10,
 ): Promise<Memory[]> {
   const all = await listMemories();
   const now = Date.now();
-  const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
 
   // クエリをトークン化
   const queryTokens = query.toLowerCase().split(/\s+/).filter((t) => t.length > 0);
-
-  // カテゴリボーナス
-  const categoryBonus: Record<MemoryCategory, number> = {
-    personality: 5,
-    routine: 4,
-    goal: 3,
-    preference: 2,
-    fact: 1,
-    context: 1,
-    other: 0,
-  };
 
   // スコアリング
   const scored = all.map((m) => {
@@ -111,14 +228,8 @@ export async function getRelevantMemories(
       }
     }
 
-    // importance 加算
-    score += m.importance;
-
-    // カテゴリボーナス
-    score += categoryBonus[m.category] ?? 0;
-
-    // 直近 7 日ボーナス
-    if (now - m.updatedAt < sevenDaysMs) score += 1;
+    // 共通スコアリング関数で指数減衰 + importance + カテゴリボーナス + アクセス頻度を加算
+    score += scoreMemory(m, now);
 
     return { memory: m, score };
   });
@@ -152,5 +263,40 @@ export async function getRelevantMemories(
     }
   }
 
+  // 返却する記憶のアクセス情報を非同期更新（non-blocking）
+  updateAccessMetrics(result.map((m) => m.id)).catch(() => {});
+
   return result;
+}
+
+/** 直近 24 時間の記憶 + アクセス上位の記憶を取得（ふりかえり用） */
+export async function getRecentMemoriesForReflection(): Promise<{ recent: Memory[]; topAccessed: Memory[] }> {
+  const all = await listMemories();
+  const now = Date.now();
+  const oneDayAgo = now - DAY_MS;
+
+  const recent = all.filter((m) => m.updatedAt >= oneDayAgo);
+
+  const topAccessed = [...all]
+    .sort((a, b) => b.accessCount - a.accessCount)
+    .slice(0, 10);
+
+  return { recent, topAccessed };
+}
+
+/** 低スコア記憶の一括アーカイブ（ふりかえりクリーンアップ用） */
+export async function cleanupLowScoredMemories(count: number = 5): Promise<number> {
+  const db = await getDB();
+  let archived = 0;
+  for (let i = 0; i < count; i++) {
+    const all = await db.getAll(STORE_NAME);
+    const normalized = (all as Memory[]).map(normalizeMemory);
+    const candidates = normalized.filter(
+      (m) => m.category !== 'personality' && m.category !== 'routine',
+    );
+    if (candidates.length === 0) break;
+    await archiveLowestScored(db, normalized);
+    archived++;
+  }
+  return archived;
 }

--- a/src/tools/memoryTool.ts
+++ b/src/tools/memoryTool.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { saveMemory, searchMemories, listMemories, deleteMemory } from '../store/memoryStore';
 import type { MemoryCategory } from '../types';
 
-const validCategories: MemoryCategory[] = ['preference', 'fact', 'context', 'routine', 'goal', 'personality', 'other'];
+const validCategories: MemoryCategory[] = ['preference', 'fact', 'context', 'routine', 'goal', 'personality', 'reflection', 'other'];
 
 export const memoryTool = tool({
   name: 'memory',
@@ -21,15 +21,16 @@ category:
 - routine: ユーザーの日課・習慣（例: 「毎朝7時にニュース確認」）
 - goal: ユーザーの目標（例: 「3月末までにレポート提出」）
 - personality: エージェントの振る舞い指示（例: 「敬語で話して」）
+- reflection: 振り返りで得た洞察やパターン
 - other: その他`,
   parameters: z.object({
     action: z.enum(['save', 'search', 'list', 'delete']),
     content: z.string().describe('保存するメモリの内容。save 時に必須、他は空文字'),
-    category: z.string().describe('カテゴリ（preference/fact/context/routine/goal/personality/other）。save 時に必須、list 時はフィルタ用、他は空文字'),
+    category: z.string().describe('カテゴリ（preference/fact/context/routine/goal/personality/reflection/other）。save 時に必須、list 時はフィルタ用、他は空文字'),
     query: z.string().describe('検索キーワード。search 時に必須、他は空文字'),
     id: z.string().describe('削除対象のメモリID。delete 時に必須、他は空文字'),
-    importance: z.string().optional().describe('重要度（1-5）。save 時のみ有効、省略時はデフォルト 3'),
-    tags: z.string().optional().describe('タグ（カンマ区切り）。save 時のみ有効、省略時は空'),
+    importance: z.string().describe('重要度（1-5）。save 時のみ有効、不要時は空文字'),
+    tags: z.string().describe('タグ（カンマ区切り）。save 時のみ有効、不要時は空文字'),
   }),
   execute: async ({ action, content, category, query, id, importance, tags }) => {
     if (action === 'save') {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -116,7 +116,7 @@ export interface AppConfig {
   persona?: PersonaConfig;
 }
 
-export type MemoryCategory = 'preference' | 'fact' | 'context' | 'routine' | 'goal' | 'personality' | 'other';
+export type MemoryCategory = 'preference' | 'fact' | 'context' | 'routine' | 'goal' | 'personality' | 'reflection' | 'other';
 
 export interface Memory {
   id: string;
@@ -126,6 +126,14 @@ export interface Memory {
   tags: string[];       // 自由形式タグ
   createdAt: number;
   updatedAt: number;
+  accessCount: number;      // 参照回数（初期値 0）
+  lastAccessedAt: number;   // 最終アクセス日時（初期値 = createdAt）
+  contentHash: string;       // SHA-256 ハッシュ（重複検出用）
+}
+
+export interface ArchivedMemory extends Memory {
+  archivedAt: number;
+  archiveReason: 'low-score' | 'manual' | 'consolidation';
 }
 
 export interface PersonaConfig {


### PR DESCRIPTION
## Summary
- **指数減衰スコアリング**: カテゴリ別半減期（personality:1年 〜 other:2週間）+ アクセス頻度ブーストで、記憶の鮮度を連続的に評価
- **コンテンツハッシュ重複排除**: SHA-256 ハッシュで同一内容の記憶を自動統合（importance 最大値採用 + tags マージ）
- **品質ベースアーカイブ**: FIFO 削除を廃止し、最低スコア記憶を memories_archive に移動（personality/routine は保護）。MAX_MEMORIES 100→200
- **Memory モデル拡張**: accessCount / lastAccessedAt / contentHash フィールド追加、ArchivedMemory 型新規
- **DB_VERSION 9→10**: contentHash / lastAccessedAt インデックス + memories_archive ストア新規作成
- **ふりかえりタスク**: reflection ビルトインタスク（23:00 固定スケジュール）+ Worker ツール 3 種（getRecentMemoriesForReflection / saveReflection / cleanupMemories）
- **reflection カテゴリ**: MemoryCategory に追加、instructionBuilder で「振り返りからの洞察」セクションとして分離表示
- **ビルトインタスク自動補完**: mergeBuiltinTasks で既存 localStorage 設定に不足しているビルトインタスクを自動追加
- **memoryTool パラメータ修正**: z.string().optional() → z.string()（OpenAI function calling スキーマバリデーション対応）
- テスト 422→448 件（+26）

## Test plan
- [x] `npm test` — 全 448 テスト通過
- [x] `npm run build` — ビルド成功
- [x] DB マイグレーション（既存データ環境でリロード → memories_archive ストア作成確認）
- [x] 設定画面で「ふりかえり」タスクが表示されることを確認
- [x] メモリ重複排除の動作確認（同一内容 2 回保存 → 1 件に統合）
- [x] reflection カテゴリの記憶が instructions 内で分離表示されることを確認（DevTools Network タブ）
- [x] memoryTool の OpenAI スキーマバリデーションエラーが解消されたことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)