### PR TITLE
feat: 日次ブリーフィング機能を追加（Phase F-1）

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,7 +23,7 @@
 - Heartbeat 3層構成（メインスレッド + Dedicated Worker + Service Worker/Push）
 - CORS プロキシ（Cloudflare Workers 拡張 — トークン認証 + SSRF 防止 + レート制限）
 - セキュリティ基盤（CSP ヘッダー + URL HTTPS 強制バリデーション）
-- テスト 448 件
+- テスト 450 件
 
 ---
 
@@ -115,6 +115,7 @@
 - [x] 結果の専用パネル（チャットとの分離）
 - [x] タスクごとの個別間隔設定（カスタムワークフロー: global/interval/fixed-time スケジュール）
 - [ ] 条件付き実行（位置情報ベース、時間帯ベース等）
+- [ ] 重要な通知のピン留め／保護（ブリーフィング等が recentResults の FIFO で押し出されない仕組み）
 
 ### Web Push 信頼性向上
 - [x] `pushsubscriptionchange` ハンドラ — Subscription 失効時の自動再登録
@@ -175,8 +176,9 @@
 - [ ] アーカイブ閲覧 UI — memories_archive の参照・復元機能
 
 ### エージェント自律性強化
-- [ ] 情報収集ワークフロー（RSS ダイジェスト、ニュースブリーフィング等の Heartbeat タスク）
-- [ ] プロアクティブ提案エンジン（日次ブリーフィング、関連情報サジェスト）
+- [x] 日次ブリーフィング — briefing-morning ビルトインタスク（07:00 固定スケジュール）+ Heartbeat プロンプトにブリーフィングルール追加
+- [ ] 情報収集ワークフロー拡張（RSS ダイジェスト等の追加 Heartbeat タスク）
+- [ ] プロアクティブ提案エンジン（関連情報サジェスト）
 - [ ] Action Planning（チェック → 判断 → アクション）
 
 ### 横断的課題
@@ -215,3 +217,4 @@
 - [x] CORS プロキシ — Cloudflare Workers 拡張（トークン認証 + SSRF 防止 + レート制限 + クライアント設定 UI）（2026-02-26）
 - [x] 外部情報収集ツール Phase C — クリッピング（clipTool + clipStore）、RSS フィード（feedTool + feedParser + feedStore + Heartbeat 連携）、Web ページ監視（webMonitorTool + monitorStore + Heartbeat 連携）、MCP Heartbeat 対応（read-only ツール許可 + 設定 UI）。DB_VERSION 7→8、4 新ストア追加。テスト 263→369 件。（2026-02-26）
 - [x] アイデンティティ + 記憶フレームワーク Phase D — 構造化記憶（importance/tags/新カテゴリ + 関連性ベース取得 + normalizeMemory 後方互換）、Agent Persona（PersonaConfig + 設定 UI + 動的 instructionBuilder）、全コンポーネント統合（agent.ts/heartbeatOpenAI.ts/heartbeatCommon.ts）。DB_VERSION 8→9。テスト 369→422 件。（2026-02-26）
+- [x] 日次ブリーフィング Phase F-1 — briefing-morning ビルトインタスク（07:00 固定スケジュール）+ Heartbeat プロンプトにブリーフィングルール追加。テスト 448→450 件。（2026-02-27）

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -30,6 +30,15 @@ describe('BUILTIN_HEARTBEAT_TASKS', () => {
     expect(weather!.enabled).toBe(false);
     expect(weather!.type).toBe('builtin');
   });
+
+  it('briefing-morning が無効で定義され、fixed-time 07:00 スケジュールを持つ', () => {
+    const briefing = BUILTIN_HEARTBEAT_TASKS.find((t) => t.id === 'briefing-morning');
+    expect(briefing).toBeDefined();
+    expect(briefing!.enabled).toBe(false);
+    expect(briefing!.type).toBe('builtin');
+    expect(briefing!.schedule).toEqual({ type: 'fixed-time', hour: 7, minute: 0 });
+    expect(briefing!.description).toContain('ブリーフィング');
+  });
 });
 
 describe('getDefaultHeartbeatConfig', () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -40,6 +40,16 @@ export const BUILTIN_HEARTBEAT_TASKS: HeartbeatTask[] = [
     type: 'builtin',
     schedule: { type: 'fixed-time', hour: 23, minute: 0 },
   },
+  {
+    id: 'briefing-morning',
+    name: '朝のブリーフィング',
+    description: '朝に本日の予定・ニュース・Web 変化・記憶をまとめたブリーフィングを生成します。'
+      + 'ツールを使って情報を収集し、優先度をつけて簡潔なサマリーを作成してください。'
+      + '必ず hasChanges: true を返し、summary にブリーフィングテキストを含めてください。',
+    enabled: false,
+    type: 'builtin',
+    schedule: { type: 'fixed-time', hour: 7, minute: 0 },
+  },
 ];
 
 export function getDefaultProxyConfig(): ProxyConfig {

--- a/src/core/instructionBuilder.test.ts
+++ b/src/core/instructionBuilder.test.ts
@@ -216,6 +216,13 @@ describe('buildHeartbeatInstructions', () => {
     expect(result).not.toContain('ユーザーについての記憶');
     expect(result).not.toContain('振り返りからの洞察');
   });
+
+  it('ブリーフィングタスク用ルールを含む', () => {
+    const result = buildHeartbeatInstructions(makeContext());
+    expect(result).toContain('ブリーフィングタスク');
+    expect(result).toContain('briefing-');
+    expect(result).toContain('総合サマリー');
+  });
 });
 
 describe('buildWorkerHeartbeatPrompt', () => {

--- a/src/core/instructionBuilder.ts
+++ b/src/core/instructionBuilder.ts
@@ -112,7 +112,8 @@ export function buildHeartbeatInstructions(ctx: InstructionContext): string {
 ルール:
 - hasChanges が false の場合、summary は空文字列にしてください
 - 通知する価値がある情報のみ hasChanges: true にしてください
-- 日本語で summary を書いてください`);
+- 日本語で summary を書いてください
+- ブリーフィングタスク（タスクIDが "briefing-" で始まるもの）は必ず hasChanges: true とし、複数のツールで収集した情報を統合した総合サマリーを summary に含めてください`);
 
   // メモリ
   const hbRegularMemories = ctx.memories.filter((m) => m.category !== 'reflection');


### PR DESCRIPTION
## Summary
- 朝 07:00 に予定・RSS 新着・Web 監視変化・記憶を統合したブリーフィングを自動生成する `briefing-morning` ビルトインタスクを追加
- Heartbeat プロンプトにブリーフィング用ルールを追加（常に `hasChanges: true` で総合サマリーを返す）
- テスト 2 件追加（タスク定義・プロンプトルール含有）
- ROADMAP 更新（日次ブリーフィング完了チェック + 通知ピン留めタスク追加 + テスト件数更新）

## Test plan
- [x] `npm test` 全 450 テスト通過
- [x] `npm run build` ビルド成功
- [x] 設定画面で「朝のブリーフィング」タスクが表示される
- [x] タスク有効化後、ブリーフィング生成を手動確認済み
- [x] HeartbeatPanel にブリーフィング結果が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)