### PR TITLE
feat: 通知ピン留め + ふりかえり UI（MemoryPanel）

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,7 +23,7 @@
 - Heartbeat 3層構成（メインスレッド + Dedicated Worker + Service Worker/Push）
 - CORS プロキシ（Cloudflare Workers 拡張 — トークン認証 + SSRF 防止 + レート制限）
 - セキュリティ基盤（CSP ヘッダー + URL HTTPS 強制バリデーション）
-- テスト 450 件
+- テスト 468 件
 
 ---
 
@@ -115,7 +115,7 @@
 - [x] 結果の専用パネル（チャットとの分離）
 - [x] タスクごとの個別間隔設定（カスタムワークフロー: global/interval/fixed-time スケジュール）
 - [ ] 条件付き実行（位置情報ベース、時間帯ベース等）
-- [ ] 重要な通知のピン留め／保護（ブリーフィング等が recentResults の FIFO で押し出されない仕組み）
+- [x] 重要な通知のピン留め／保護（ブリーフィング等が recentResults の FIFO で押し出されない仕組み）
 
 ### Web Push 信頼性向上
 - [x] `pushsubscriptionchange` ハンドラ — Subscription 失効時の自動再登録
@@ -172,7 +172,7 @@
 - [x] DB_VERSION 9→10（contentHash/lastAccessedAt インデックス + memories_archive ストア）
 - [x] ふりかえりタスク — reflection ビルトインタスク（23:00 固定スケジュール）+ Worker ツール 3 種（getRecentMemoriesForReflection/saveReflection/cleanupMemories）
 - [x] reflection カテゴリ — MemoryCategory に追加 + instructionBuilder で「振り返りからの洞察」分離表示
-- [ ] ふりかえり UI — reflection 記憶の閲覧・管理画面
+- [x] ふりかえり UI — reflection 記憶の閲覧・管理画面（MemoryPanel コンポーネント）
 - [ ] アーカイブ閲覧 UI — memories_archive の参照・復元機能
 
 ### エージェント自律性強化
@@ -218,3 +218,4 @@
 - [x] 外部情報収集ツール Phase C — クリッピング（clipTool + clipStore）、RSS フィード（feedTool + feedParser + feedStore + Heartbeat 連携）、Web ページ監視（webMonitorTool + monitorStore + Heartbeat 連携）、MCP Heartbeat 対応（read-only ツール許可 + 設定 UI）。DB_VERSION 7→8、4 新ストア追加。テスト 263→369 件。（2026-02-26）
 - [x] アイデンティティ + 記憶フレームワーク Phase D — 構造化記憶（importance/tags/新カテゴリ + 関連性ベース取得 + normalizeMemory 後方互換）、Agent Persona（PersonaConfig + 設定 UI + 動的 instructionBuilder）、全コンポーネント統合（agent.ts/heartbeatOpenAI.ts/heartbeatCommon.ts）。DB_VERSION 8→9。テスト 369→422 件。（2026-02-26）
 - [x] 日次ブリーフィング Phase F-1 — briefing-morning ビルトインタスク（07:00 固定スケジュール）+ Heartbeat プロンプトにブリーフィングルール追加。テスト 448→450 件。（2026-02-27）
+- [x] 通知ピン留め + ふりかえり UI — HeartbeatResult pinned フィールド + FIFO 保護 + togglePin + 自動ピン付与（briefing-*/reflection）+ HeartbeatPanel ピン UI + MemoryPanel（記憶管理パネル: カテゴリフィルタ・削除）+ listArchivedMemories。テスト 450→468 件。（2026-02-27）

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, lazy, Suspense } from 'react';
 import { ChatView } from './components/ChatView';
 import { ConversationSidebar } from './components/ConversationSidebar';
 import { HeartbeatPanel } from './components/HeartbeatPanel';
+import { MemoryPanel } from './components/MemoryPanel';
 const SettingsModal = lazy(() =>
   import('./components/SettingsModal').then((m) => ({ default: m.SettingsModal }))
 );
@@ -9,6 +10,7 @@ import { useAgentChat } from './hooks/useAgentChat';
 import { useConversations } from './hooks/useConversations';
 import { useHeartbeat } from './hooks/useHeartbeat';
 import { useHeartbeatPanel } from './hooks/useHeartbeatPanel';
+import { useMemoryPanel } from './hooks/useMemoryPanel';
 import { isConfigured, getConfig } from './core/config';
 import { mcpManager } from './core/mcpManager';
 import { saveMessage } from './store/conversationStore';
@@ -37,6 +39,7 @@ export default function App() {
     useAgentChat(activeConversationId);
 
   const heartbeatPanel = useHeartbeatPanel();
+  const memoryPanel = useMemoryPanel();
 
   const handleHeartbeatNotification = useCallback((notification: HeartbeatNotification) => {
     if (!activeConversationId) return;
@@ -173,6 +176,16 @@ export default function App() {
             <button className="btn-icon" onClick={handleSidebarCreate} title="新しい会話">
               +
             </button>
+            <MemoryPanel
+              isOpen={memoryPanel.isOpen}
+              memories={memoryPanel.memories}
+              selectedCategory={memoryPanel.selectedCategory}
+              isLoading={memoryPanel.isLoading}
+              onToggle={memoryPanel.toggle}
+              onClose={memoryPanel.close}
+              onChangeCategory={memoryPanel.changeCategory}
+              onDelete={memoryPanel.handleDelete}
+            />
             {heartbeatEnabled && (
               <HeartbeatPanel
                 isOpen={heartbeatPanel.isOpen}
@@ -180,6 +193,7 @@ export default function App() {
                 unreadCount={heartbeatPanel.unreadCount}
                 onToggle={heartbeatPanel.toggle}
                 onClose={heartbeatPanel.close}
+                onTogglePin={heartbeatPanel.togglePin}
               />
             )}
             <button className="btn-icon" onClick={() => setSettingsOpen(true)} title="設定">

--- a/src/components/HeartbeatPanel.test.tsx
+++ b/src/components/HeartbeatPanel.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HeartbeatPanel } from './HeartbeatPanel';
+import type { HeartbeatResult } from '../types';
+
+describe('HeartbeatPanel', () => {
+  const baseProps = {
+    isOpen: true,
+    results: [] as HeartbeatResult[],
+    unreadCount: 0,
+    onToggle: vi.fn(),
+    onClose: vi.fn(),
+    onTogglePin: vi.fn(),
+  };
+
+  it('ピン留め結果にピンアイコン（📌）が表示される', () => {
+    const results: HeartbeatResult[] = [
+      { taskId: 'briefing-morning', timestamp: 1000, hasChanges: true, summary: 'ブリーフィング', pinned: true },
+    ];
+    render(<HeartbeatPanel {...baseProps} results={results} />);
+
+    expect(screen.getByText('📌')).toBeDefined();
+  });
+
+  it('ピンボタンクリックで onTogglePin が呼ばれる', async () => {
+    const onTogglePin = vi.fn();
+    const results: HeartbeatResult[] = [
+      { taskId: 'task-1', timestamp: 2000, hasChanges: false, summary: 'テスト結果' },
+    ];
+    render(<HeartbeatPanel {...baseProps} results={results} onTogglePin={onTogglePin} />);
+
+    const pinButton = screen.getByTitle('ピン留め');
+    await userEvent.click(pinButton);
+
+    expect(onTogglePin).toHaveBeenCalledWith('task-1', 2000);
+  });
+
+  it('ピン留め結果に heartbeat-result-pinned クラスが付与される', () => {
+    const results: HeartbeatResult[] = [
+      { taskId: 'task-pinned', timestamp: 3000, hasChanges: true, summary: 'ピン留め結果', pinned: true },
+      { taskId: 'task-normal', timestamp: 4000, hasChanges: false, summary: '通常結果' },
+    ];
+    const { container } = render(<HeartbeatPanel {...baseProps} results={results} />);
+
+    const items = container.querySelectorAll('.heartbeat-result-item');
+    expect(items[0].classList.contains('heartbeat-result-pinned')).toBe(true);
+    expect(items[1].classList.contains('heartbeat-result-pinned')).toBe(false);
+  });
+});

--- a/src/components/HeartbeatPanel.tsx
+++ b/src/components/HeartbeatPanel.tsx
@@ -7,6 +7,7 @@ interface HeartbeatPanelProps {
   unreadCount: number;
   onToggle: () => void;
   onClose: () => void;
+  onTogglePin: (taskId: string, timestamp: number) => void;
 }
 
 function formatTime(ts: number): string {
@@ -19,7 +20,7 @@ function formatTime(ts: number): string {
   return d.toLocaleDateString('ja-JP', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
 }
 
-export function HeartbeatPanel({ isOpen, results, unreadCount, onToggle, onClose }: HeartbeatPanelProps) {
+export function HeartbeatPanel({ isOpen, results, unreadCount, onToggle, onClose, onTogglePin }: HeartbeatPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
 
   // パネル外クリックで閉じる
@@ -57,9 +58,20 @@ export function HeartbeatPanel({ isOpen, results, unreadCount, onToggle, onClose
               results.map((r, i) => (
                 <div
                   key={`${r.taskId}-${r.timestamp}-${i}`}
-                  className={`heartbeat-result-item${r.hasChanges ? ' heartbeat-result-changed' : ''}`}
+                  className={`heartbeat-result-item${r.hasChanges ? ' heartbeat-result-changed' : ''}${r.pinned ? ' heartbeat-result-pinned' : ''}`}
                 >
-                  <div className="heartbeat-result-summary">{r.summary || '変化なし'}</div>
+                  <div className="heartbeat-result-header">
+                    <div className="heartbeat-result-summary">{r.summary || '変化なし'}</div>
+                    <button
+                      className="btn-pin"
+                      onClick={() => onTogglePin(r.taskId, r.timestamp)}
+                      title={r.pinned ? 'ピン留め解除' : 'ピン留め'}
+                    >
+                      <span className={`heartbeat-pin-icon${r.pinned ? ' pinned' : ''}`}>
+                        {r.pinned ? '📌' : '📍'}
+                      </span>
+                    </button>
+                  </div>
                   <div className="heartbeat-result-meta">
                     <span>{r.taskId}</span>
                     <span>{formatTime(r.timestamp)}</span>

--- a/src/components/MemoryPanel.test.tsx
+++ b/src/components/MemoryPanel.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryPanel } from './MemoryPanel';
+import type { Memory } from '../types';
+
+function makeMemory(overrides?: Partial<Memory>): Memory {
+  return {
+    id: crypto.randomUUID(),
+    content: 'テストメモリ',
+    category: 'fact',
+    importance: 3,
+    tags: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    accessCount: 0,
+    lastAccessedAt: Date.now(),
+    contentHash: '',
+    ...overrides,
+  };
+}
+
+describe('MemoryPanel', () => {
+  const baseProps = {
+    isOpen: true,
+    memories: [] as Memory[],
+    selectedCategory: undefined as undefined,
+    isLoading: false,
+    onToggle: vi.fn(),
+    onClose: vi.fn(),
+    onChangeCategory: vi.fn(),
+    onDelete: vi.fn(),
+  };
+
+  it('ドロップダウンが isOpen=true のとき表示される', () => {
+    const { container } = render(<MemoryPanel {...baseProps} isOpen={true} />);
+    expect(container.querySelector('.memory-dropdown')).toBeTruthy();
+  });
+
+  it('ドロップダウンが isOpen=false のとき非表示', () => {
+    const { container } = render(<MemoryPanel {...baseProps} isOpen={false} />);
+    expect(container.querySelector('.memory-dropdown')).toBeNull();
+  });
+
+  it('カテゴリタブが表示されクリックで onChangeCategory が呼ばれる', async () => {
+    const onChangeCategory = vi.fn();
+    render(<MemoryPanel {...baseProps} onChangeCategory={onChangeCategory} />);
+
+    const reflectionTab = screen.getByText('ふりかえり');
+    await userEvent.click(reflectionTab);
+
+    expect(onChangeCategory).toHaveBeenCalledWith('reflection');
+  });
+
+  it('メモリカードの削除ボタンクリックで onDelete が呼ばれる', async () => {
+    const onDelete = vi.fn();
+    const memories = [makeMemory({ id: 'mem-1', content: '削除対象メモリ' })];
+    render(<MemoryPanel {...baseProps} memories={memories} onDelete={onDelete} />);
+
+    const deleteBtn = screen.getByTitle('削除');
+    await userEvent.click(deleteBtn);
+
+    expect(onDelete).toHaveBeenCalledWith('mem-1');
+  });
+
+  it('記憶が空のとき空状態メッセージが表示される', () => {
+    render(<MemoryPanel {...baseProps} memories={[]} />);
+    expect(screen.getByText('記憶がありません')).toBeDefined();
+  });
+});

--- a/src/components/MemoryPanel.tsx
+++ b/src/components/MemoryPanel.tsx
@@ -1,0 +1,152 @@
+import { useRef, useEffect } from 'react';
+import type { Memory, MemoryCategory } from '../types';
+
+interface MemoryPanelProps {
+  isOpen: boolean;
+  memories: Memory[];
+  selectedCategory: MemoryCategory | undefined;
+  isLoading: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+  onChangeCategory: (category: MemoryCategory | undefined) => void;
+  onDelete: (id: string) => void;
+}
+
+const CATEGORY_LABELS: Record<MemoryCategory, string> = {
+  reflection: 'ふりかえり',
+  preference: '好み',
+  fact: '事実',
+  routine: '習慣',
+  goal: '目標',
+  personality: '性格',
+  context: '文脈',
+  other: 'その他',
+};
+
+const CATEGORY_COLORS: Record<MemoryCategory, string> = {
+  reflection: '#a78bfa',
+  preference: '#60a5fa',
+  fact: '#34d399',
+  routine: '#fbbf24',
+  goal: '#f472b6',
+  personality: '#fb923c',
+  context: '#94a3b8',
+  other: '#6b7280',
+};
+
+const FILTER_CATEGORIES: (MemoryCategory | undefined)[] = [
+  undefined,
+  'reflection',
+  'preference',
+  'fact',
+  'routine',
+  'goal',
+  'personality',
+  'context',
+  'other',
+];
+
+function formatDate(ts: number): string {
+  const d = new Date(ts);
+  const now = new Date();
+  const isToday = d.toDateString() === now.toDateString();
+  if (isToday) {
+    return d.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
+  }
+  return d.toLocaleDateString('ja-JP', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+}
+
+export function MemoryPanel({
+  isOpen,
+  memories,
+  selectedCategory,
+  isLoading,
+  onToggle,
+  onClose,
+  onChangeCategory,
+  onDelete,
+}: MemoryPanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // パネル外クリックで閉じる
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [isOpen, onClose]);
+
+  return (
+    <div className="memory-panel-container" ref={panelRef}>
+      <button className="btn-icon memory-brain" onClick={onToggle} title="記憶管理">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+          <path d="M2 6c0-2.2 1.8-4 4-4 .7 0 1.4.2 2 .5.6-.3 1.3-.5 2-.5 2.2 0 4 1.8 4 4 0 1-.4 2-1 2.7.6.7 1 1.6 1 2.6 0 2.1-1.6 3.7-3.7 3.7-.8 0-1.5-.2-2.1-.7-.3.1-.5.2-.8.2h-.8c-.3 0-.5-.1-.8-.2-.6.5-1.3.7-2.1.7C2.6 15.3 1 13.7 1 11.6c0-1 .4-1.9 1-2.6-.6-.8-1-1.7-1-2.7 0-.1 0-.2.01-.3H2zm1 0c0 .8.4 1.5 1 2-.1.2-.2.3-.2.5 0 .4.2.7.4 1-.5.6-.7 1.3-.7 2.1 0 1.5 1.1 2.7 2.7 2.7.6 0 1.2-.2 1.6-.6.3.2.7.3 1 .3h.4c.3 0 .7-.1 1-.3.4.4 1 .6 1.6.6 1.5 0 2.7-1.1 2.7-2.7 0-.8-.3-1.5-.7-2.1.2-.3.4-.6.4-1 0-.2-.1-.3-.2-.5.6-.5 1-1.2 1-2 0-1.7-1.3-3-3-3-.5 0-1 .1-1.4.4L8 3.7l-.6-.3C7 3.1 6.5 3 6 3 4.3 3 3 4.3 3 6z" />
+        </svg>
+      </button>
+      {isOpen && (
+        <div className="memory-dropdown">
+          <div className="memory-dropdown-header">
+            記憶管理
+            <span className="memory-dropdown-count">{memories.length}件</span>
+          </div>
+          <div className="memory-category-tabs">
+            {FILTER_CATEGORIES.map((cat) => (
+              <button
+                key={cat ?? 'all'}
+                className={`memory-tab${selectedCategory === cat ? ' memory-tab-active' : ''}`}
+                onClick={() => onChangeCategory(cat)}
+              >
+                {cat ? CATEGORY_LABELS[cat] : '全て'}
+              </button>
+            ))}
+          </div>
+          <div className="memory-dropdown-list">
+            {isLoading ? (
+              <div className="memory-dropdown-empty">読み込み中...</div>
+            ) : memories.length === 0 ? (
+              <div className="memory-dropdown-empty">記憶がありません</div>
+            ) : (
+              memories.map((m) => (
+                <div key={m.id} className="memory-card">
+                  <div className="memory-card-header">
+                    <span
+                      className="memory-category-badge"
+                      style={{ background: CATEGORY_COLORS[m.category] + '22', color: CATEGORY_COLORS[m.category] }}
+                    >
+                      {CATEGORY_LABELS[m.category]}
+                    </span>
+                    <span className="memory-importance">
+                      {'★'.repeat(m.importance)}{'☆'.repeat(5 - m.importance)}
+                    </span>
+                    <button
+                      className="memory-delete-btn"
+                      onClick={() => onDelete(m.id)}
+                      title="削除"
+                    >
+                      ×
+                    </button>
+                  </div>
+                  <div className="memory-card-content">{m.content}</div>
+                  <div className="memory-card-footer">
+                    {m.tags.length > 0 && (
+                      <div className="memory-tags">
+                        {m.tags.map((tag) => (
+                          <span key={tag} className="memory-tag">#{tag}</span>
+                        ))}
+                      </div>
+                    )}
+                    <span className="memory-card-date">{formatDate(m.updatedAt)}</span>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/core/heartbeat.ts
+++ b/src/core/heartbeat.ts
@@ -198,6 +198,7 @@ export class HeartbeatEngine {
           timestamp: now,
           hasChanges: r.hasChanges,
           summary: r.summary || '',
+          pinned: r.taskId.startsWith('briefing-') || r.taskId === 'reflection',
         };
         await addHeartbeatResult(hbResult);
         await updateTaskLastRun(r.taskId, now);

--- a/src/core/heartbeatCommon.ts
+++ b/src/core/heartbeatCommon.ts
@@ -109,7 +109,11 @@ export async function executeHeartbeatAndStore(apiKey: string, source?: Heartbea
   console.log(`[Heartbeat:${label}] ${results.length} 件のタスクを実行`);
 
   for (const r of results) {
-    const tagged = { ...r, source };
+    const tagged = {
+      ...r,
+      source,
+      pinned: r.taskId.startsWith('briefing-') || r.taskId === 'reflection',
+    };
     await addHeartbeatResult(tagged);
     await updateTaskLastRun(r.taskId, now);
     if (r.hasChanges) {

--- a/src/hooks/useHeartbeatPanel.ts
+++ b/src/hooks/useHeartbeatPanel.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import { loadHeartbeatState } from '../store/heartbeatStore';
+import { loadHeartbeatState, togglePinHeartbeatResult } from '../store/heartbeatStore';
 import type { HeartbeatResult } from '../types';
 
 const LAST_READ_KEY = 'iagent-heartbeat-last-read';
@@ -36,6 +36,11 @@ export function useHeartbeatPanel() {
     setIsOpen(false);
   }, []);
 
+  const togglePin = useCallback(async (taskId: string, timestamp: number) => {
+    await togglePinHeartbeatResult(taskId, timestamp);
+    await refresh();
+  }, [refresh]);
+
   // 初回マウント時にデータ読み込み（非同期の外部ストア同期）
   useEffect(() => {
     loadHeartbeatState().then((state) => {
@@ -43,5 +48,5 @@ export function useHeartbeatPanel() {
     });
   }, []);
 
-  return { isOpen, results, unreadCount, toggle, close, markAsRead, refresh };
+  return { isOpen, results, unreadCount, toggle, close, markAsRead, refresh, togglePin };
 }

--- a/src/hooks/useMemoryPanel.test.ts
+++ b/src/hooks/useMemoryPanel.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { __resetStores } from '../store/__mocks__/db';
+
+vi.mock('../store/db');
+
+import { useMemoryPanel } from './useMemoryPanel';
+import { saveMemory } from '../store/memoryStore';
+
+beforeEach(() => {
+  __resetStores();
+});
+
+describe('useMemoryPanel', () => {
+  it('toggle でパネルの開閉を切り替えできる', async () => {
+    const { result } = renderHook(() => useMemoryPanel());
+
+    expect(result.current.isOpen).toBe(false);
+
+    await act(async () => {
+      result.current.toggle();
+    });
+    expect(result.current.isOpen).toBe(true);
+
+    await act(async () => {
+      result.current.toggle();
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('changeCategory でカテゴリを切り替えできる', async () => {
+    await saveMemory('事実メモリ', 'fact');
+    await saveMemory('好みメモリ', 'preference');
+
+    const { result } = renderHook(() => useMemoryPanel());
+
+    await act(async () => {
+      result.current.changeCategory('fact');
+    });
+
+    expect(result.current.selectedCategory).toBe('fact');
+    expect(result.current.memories.every((m) => m.category === 'fact')).toBe(true);
+  });
+
+  it('handleDelete でメモリを削除できる', async () => {
+    const mem = await saveMemory('削除テスト', 'other');
+
+    const { result } = renderHook(() => useMemoryPanel());
+
+    // refresh で初期データを読み込み
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.memories).toHaveLength(1);
+
+    await act(async () => {
+      await result.current.handleDelete(mem.id);
+    });
+    expect(result.current.memories).toHaveLength(0);
+  });
+
+  it('close でパネルを閉じる', async () => {
+    const { result } = renderHook(() => useMemoryPanel());
+
+    await act(async () => {
+      result.current.toggle();
+    });
+    expect(result.current.isOpen).toBe(true);
+
+    await act(async () => {
+      result.current.close();
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+});

--- a/src/hooks/useMemoryPanel.ts
+++ b/src/hooks/useMemoryPanel.ts
@@ -1,0 +1,53 @@
+import { useState, useCallback, useEffect } from 'react';
+import { listMemories, deleteMemory } from '../store/memoryStore';
+import type { Memory, MemoryCategory } from '../types';
+
+export function useMemoryPanel() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [memories, setMemories] = useState<Memory[]>([]);
+  const [selectedCategory, setSelectedCategory] = useState<MemoryCategory | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const refresh = useCallback(async (category?: MemoryCategory) => {
+    setIsLoading(true);
+    try {
+      const data = await listMemories(category);
+      setMemories(data);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const toggle = useCallback(() => {
+    setIsOpen((prev) => {
+      const next = !prev;
+      if (next) {
+        refresh(selectedCategory);
+      }
+      return next;
+    });
+  }, [refresh, selectedCategory]);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const changeCategory = useCallback((category: MemoryCategory | undefined) => {
+    setSelectedCategory(category);
+    refresh(category);
+  }, [refresh]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    await deleteMemory(id);
+    await refresh(selectedCategory);
+  }, [refresh, selectedCategory]);
+
+  // 初回マウント時にデータ読み込み
+  useEffect(() => {
+    listMemories().then((data) => {
+      setMemories(data);
+    });
+  }, []);
+
+  return { isOpen, memories, selectedCategory, isLoading, toggle, close, changeCategory, handleDelete, refresh };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1036,6 +1036,46 @@ body {
   color: var(--text-muted);
 }
 
+/* Heartbeat pinned result */
+.heartbeat-result-pinned {
+  border-left: 3px solid #f59e0b;
+  background: rgba(245, 158, 11, 0.05);
+}
+
+.heartbeat-result-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.heartbeat-result-header .heartbeat-result-summary {
+  flex: 1;
+}
+
+.heartbeat-pin-icon {
+  font-size: 12px;
+  opacity: 0.4;
+  transition: opacity 0.15s;
+}
+
+.heartbeat-pin-icon.pinned {
+  opacity: 1;
+}
+
+.btn-pin {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px 4px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.btn-pin:hover .heartbeat-pin-icon {
+  opacity: 1;
+}
+
 /* Heartbeat message badge */
 .message-heartbeat .message-bubble {
   border-left: 3px solid #4ade80;
@@ -1104,6 +1144,182 @@ body {
   line-height: 1.4;
 }
 
+/* Memory panel */
+.memory-panel-container {
+  position: relative;
+}
+
+.memory-brain {
+  position: relative;
+}
+
+.memory-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 400px;
+  max-height: 520px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.memory-dropdown-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.memory-dropdown-count {
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--text-muted);
+}
+
+.memory-category-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.memory-tab {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 11px;
+  padding: 3px 8px;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.memory-tab:hover {
+  color: var(--text);
+  border-color: var(--accent);
+}
+
+.memory-tab-active {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+
+.memory-dropdown-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.memory-dropdown-empty {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 13px;
+  padding: 24px 16px;
+}
+
+.memory-card {
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  transition: background 0.15s;
+}
+
+.memory-card:last-child {
+  border-bottom: none;
+}
+
+.memory-card:hover {
+  background: var(--bg-tertiary);
+}
+
+.memory-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.memory-category-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 8px;
+}
+
+.memory-importance {
+  font-size: 10px;
+  color: var(--text-muted);
+  letter-spacing: -1px;
+}
+
+.memory-delete-btn {
+  display: none;
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 16px;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+}
+
+.memory-delete-btn:hover {
+  color: #f87171;
+}
+
+.memory-card:hover .memory-delete-btn {
+  display: block;
+}
+
+.memory-card-content {
+  font-size: 13px;
+  color: var(--text);
+  line-height: 1.5;
+  margin-bottom: 4px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.memory-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.memory-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.memory-tag {
+  font-size: 10px;
+  color: var(--accent);
+  background: rgba(59, 130, 246, 0.1);
+  padding: 1px 6px;
+  border-radius: 8px;
+}
+
+.memory-card-date {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  margin-left: auto;
+}
+
 /* PWA standalone mode */
 @media (display-mode: standalone) {
   .app-header {
@@ -1150,6 +1366,11 @@ body {
     width: calc(100vw - 32px);
     right: -8px;
   }
+
+  .memory-dropdown {
+    width: calc(100vw - 32px);
+    right: -8px;
+  }
 }
 
 @media (max-width: 600px) {
@@ -1163,6 +1384,17 @@ body {
   }
 
   .heartbeat-dropdown {
+    position: fixed;
+    top: auto;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    max-height: 60vh;
+    border-radius: var(--radius) var(--radius) 0 0;
+  }
+
+  .memory-dropdown {
     position: fixed;
     top: auto;
     bottom: 0;

--- a/src/store/heartbeatStore.test.ts
+++ b/src/store/heartbeatStore.test.ts
@@ -10,6 +10,7 @@ import {
   addHeartbeatResult,
   updateTaskLastRun,
   getTaskLastRun,
+  togglePinHeartbeatResult,
 } from './heartbeatStore';
 import type { HeartbeatResult, HeartbeatState } from '../types';
 
@@ -108,6 +109,93 @@ describe('addHeartbeatResult', () => {
     expect(state.recentResults).toHaveLength(50);
     // 最新が先頭
     expect(state.recentResults[0].taskId).toBe('task-54');
+  });
+});
+
+describe('addHeartbeatResult (pinned 保護)', () => {
+  it('pinned 結果が FIFO で押し出されない', async () => {
+    // pinned 結果を 3 件追加
+    for (let i = 0; i < 3; i++) {
+      await addHeartbeatResult({
+        taskId: `pinned-${i}`,
+        timestamp: i * 1000,
+        hasChanges: true,
+        summary: `ピン留め ${i}`,
+        pinned: true,
+      });
+    }
+    // unpinned 結果を 50 件追加（上限超過を引き起こす）
+    for (let i = 0; i < 50; i++) {
+      await addHeartbeatResult({
+        taskId: `unpinned-${i}`,
+        timestamp: (i + 100) * 1000,
+        hasChanges: false,
+        summary: `通常 ${i}`,
+      });
+    }
+
+    const state = await loadHeartbeatState();
+    expect(state.recentResults).toHaveLength(50);
+    // pinned 結果がすべて残っている
+    const pinnedResults = state.recentResults.filter(r => r.pinned);
+    expect(pinnedResults).toHaveLength(3);
+    for (let i = 0; i < 3; i++) {
+      expect(pinnedResults.find(r => r.taskId === `pinned-${i}`)).toBeDefined();
+    }
+  });
+
+  it('pinned が上限を超えてもすべて保持される', async () => {
+    // pinned 結果を 55 件追加
+    for (let i = 0; i < 55; i++) {
+      await addHeartbeatResult({
+        taskId: `pinned-${i}`,
+        timestamp: i * 1000,
+        hasChanges: true,
+        summary: `ピン留め ${i}`,
+        pinned: true,
+      });
+    }
+
+    const state = await loadHeartbeatState();
+    // すべての pinned が保持される（上限超えても pinned は削除されない）
+    expect(state.recentResults.length).toBeGreaterThanOrEqual(55);
+    const pinnedResults = state.recentResults.filter(r => r.pinned);
+    expect(pinnedResults).toHaveLength(55);
+  });
+});
+
+describe('togglePinHeartbeatResult', () => {
+  it('結果のピン状態を切り替えできる', async () => {
+    await addHeartbeatResult({
+      taskId: 'task-1',
+      timestamp: 1000,
+      hasChanges: true,
+      summary: 'テスト',
+    });
+
+    // ピン留め
+    await togglePinHeartbeatResult('task-1', 1000);
+    let state = await loadHeartbeatState();
+    expect(state.recentResults[0].pinned).toBe(true);
+
+    // ピン解除
+    await togglePinHeartbeatResult('task-1', 1000);
+    state = await loadHeartbeatState();
+    expect(state.recentResults[0].pinned).toBe(false);
+  });
+
+  it('存在しない結果に対しては何もしない', async () => {
+    await addHeartbeatResult({
+      taskId: 'task-1',
+      timestamp: 1000,
+      hasChanges: true,
+      summary: 'テスト',
+    });
+
+    await togglePinHeartbeatResult('nonexistent', 9999);
+    const state = await loadHeartbeatState();
+    expect(state.recentResults).toHaveLength(1);
+    expect(state.recentResults[0].pinned).toBeUndefined();
   });
 });
 

--- a/src/store/heartbeatStore.ts
+++ b/src/store/heartbeatStore.ts
@@ -45,8 +45,21 @@ export async function addHeartbeatResult(result: HeartbeatResult): Promise<void>
   const state = await loadHeartbeatState();
   state.recentResults.unshift(result);
   if (state.recentResults.length > MAX_RECENT_RESULTS) {
-    state.recentResults = state.recentResults.slice(0, MAX_RECENT_RESULTS);
+    const pinned = state.recentResults.filter(r => r.pinned);
+    const unpinned = state.recentResults.filter(r => !r.pinned);
+    const unpinnedLimit = MAX_RECENT_RESULTS - pinned.length;
+    state.recentResults = [...pinned, ...unpinned.slice(0, Math.max(0, unpinnedLimit))];
+    state.recentResults.sort((a, b) => b.timestamp - a.timestamp);
   }
   state.lastChecked = result.timestamp;
   await saveHeartbeatState(state);
+}
+
+export async function togglePinHeartbeatResult(taskId: string, timestamp: number): Promise<void> {
+  const state = await loadHeartbeatState();
+  const target = state.recentResults.find(r => r.taskId === taskId && r.timestamp === timestamp);
+  if (target) {
+    target.pinned = !target.pinned;
+    await saveHeartbeatState(state);
+  }
 }

--- a/src/store/memoryStore.test.ts
+++ b/src/store/memoryStore.test.ts
@@ -15,6 +15,7 @@ import {
   computeContentHash,
   getRecentMemoriesForReflection,
   cleanupLowScoredMemories,
+  listArchivedMemories,
   HALF_LIFE_MS,
 } from './memoryStore';
 import type { Memory } from '../types';
@@ -460,5 +461,36 @@ describe('cleanupLowScoredMemories', () => {
     const after = await listMemories();
     expect(after).toHaveLength(2);
     expect(after.map((m) => m.category)).toEqual(expect.arrayContaining(['personality', 'routine']));
+  });
+});
+
+describe('listArchivedMemories', () => {
+  it('アーカイブ済み記憶を取得できる', async () => {
+    // 複数のメモリを保存して低スコアをアーカイブ
+    for (let i = 0; i < 5; i++) {
+      await saveMemory(`メモリ ${i}`, 'other');
+    }
+    await cleanupLowScoredMemories(2);
+
+    const archived = await listArchivedMemories();
+    expect(archived).toHaveLength(2);
+    expect(archived[0].archivedAt).toBeGreaterThan(0);
+    expect(archived[0].archiveReason).toBe('low-score');
+  });
+
+  it('カテゴリ指定でアーカイブをフィルタできる', async () => {
+    await saveMemory('事実1', 'fact');
+    await saveMemory('その他1', 'other');
+    await saveMemory('その他2', 'other');
+    await cleanupLowScoredMemories(2);
+
+    const archived = await listArchivedMemories();
+    // アーカイブが存在する場合のみカテゴリフィルタを検証
+    if (archived.length > 0) {
+      const categories = archived.map((a) => a.category);
+      const factArchived = await listArchivedMemories('fact');
+      const otherArchived = await listArchivedMemories('other');
+      expect(factArchived.length + otherArchived.length).toBeLessThanOrEqual(archived.length);
+    }
   });
 });

--- a/src/store/memoryStore.ts
+++ b/src/store/memoryStore.ts
@@ -269,6 +269,17 @@ export async function getRelevantMemories(
   return result;
 }
 
+/** アーカイブ済み記憶の一覧を取得 */
+export async function listArchivedMemories(category?: MemoryCategory): Promise<ArchivedMemory[]> {
+  const db = await getDB();
+  if (category) {
+    const results = await db.getAllFromIndex(ARCHIVE_STORE_NAME, 'category', category);
+    return (results as ArchivedMemory[]).sort((a, b) => b.archivedAt - a.archivedAt);
+  }
+  const all = await db.getAll(ARCHIVE_STORE_NAME);
+  return (all as ArchivedMemory[]).sort((a, b) => b.archivedAt - a.archivedAt);
+}
+
 /** 直近 24 時間の記憶 + アクセス上位の記憶を取得（ふりかえり用） */
 export async function getRecentMemoriesForReflection(): Promise<{ recent: Memory[]; topAccessed: Memory[] }> {
   const all = await listMemories();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -67,6 +67,7 @@ export interface HeartbeatResult {
   hasChanges: boolean;
   summary: string;
   source?: HeartbeatSource;
+  pinned?: boolean;
 }
 
 export interface HeartbeatState {


### PR DESCRIPTION
## Summary
- HeartbeatResult に `pinned` フィールド追加。FIFO で pinned 結果を保護し、briefing-*/reflection タスク結果を自動ピン付与
- HeartbeatPanel にピンアイコン・トグルボタンを追加（視覚的区別: 黄色左ボーダー + 背景色）
- MemoryPanel 新規作成: ヘッダーの脳アイコンから記憶一覧を閲覧（カテゴリフィルタ・削除・レスポンシブ対応）
- `listArchivedMemories` API を memoryStore に追加（将来のアーカイブ閲覧 UI 基盤）
- テスト 450→468 件（+18 件: store/component/hook テスト）

## Test plan
- [x] `npm test` — 全 468 テスト通過
- [x] `npm run build` — ビルド成功
- [ ] HeartbeatPanel でブリーフィング結果にピンアイコンが表示される
- [ ] ピン留め結果が FIFO で押し出されない
- [ ] ピン留め/解除ボタンが動作する
- [ ] ヘッダーに脳アイコン（MemoryPanel）が表示される
- [ ] MemoryPanel でカテゴリフィルタ・削除が動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)