### PR TITLE
fix: getAllFromIndex モックの multiEntry インデックス対応（PR-G）

### DIFF
--- a/docs/REVIEW-TRACKER.md
+++ b/docs/REVIEW-TRACKER.md
@@ -205,6 +205,15 @@ PR#1〜#24 に付いた全レビューコメントを一元管理する。
 
 ---
 
+## 対応済み（PR-G で修正）
+
+### getAllFromIndex モックの正確性改善 [テスト]
+- **PR**: #2 (Copilot), PR-G で修正
+- **内容**: `__mocks__/db.ts` の `getAllFromIndex` が multiEntry インデックス（配列フィールド）に非対応
+- **修正**: `getAllFromIndex` と `transaction.index().getAll()` のフィルタで `Array.isArray(value) ? value.includes(query) : value === query` に変更。clipStore.test.ts に multiEntry タグフィルタの検証テスト追加
+
+---
+
 ## 将来対応
 
 ### Notification API パーミッション再レンダリング [UX]
@@ -216,11 +225,6 @@ PR#1〜#24 に付いた全レビューコメントを一元管理する。
 - **PR**: #1 (Copilot)
 - **内容**: デスクトップ通知に icon プロパティ未設定
 - **優先度**: 低
-
-### getAllFromIndex モックの正確性改善 [テスト]
-- **PR**: #2 (Copilot)
-- **内容**: `__mocks__/db.ts` の `getAllFromIndex` が indexName を無視
-- **優先度**: 中
 
 ### memoryTool category バリデーション [コード品質]
 - **PR**: #2 (Copilot)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -233,3 +233,4 @@
 - [x] Push 通知信頼性改善 PR-D — subscribePush 既存 Subscription 再登録時の response.ok チェック追加（4xx はデータ不正として新規作成、5xx/ネットワークエラーは既存継続）、Push 関連レビュー項目 3 件のステータス更新（2 件は既に対応済み確認 + 1 件修正）。テスト 474→477 件。（2026-02-28）
 - [x] クライアント側 SSRF 防止 PR-E — `isPrivateIP()` を `server/src/proxy.ts` から `src/core/urlValidation.ts` に移植、`validateUrl()` でプライベート IP ブロック（localhost 除外）。DNS rebinding はブラウザ JS では原理的に検出不可だが CORS プロキシ + サーバー側で多層防御済み。（2026-02-28）
 - [x] MCP ツール許可改善 PR-F — `allowedMcpTools` を `"serverName/toolName"` 形式に変更（server-qualified 化）+ callable `toolFilter` でサーバー単位フィルタリング + `groupTasksByMcpTools` でタスク単位のツール分離（グループごとに個別 Agent 実行）。（2026-02-28）
+- [x] getAllFromIndex モック正確性改善 PR-G — `__mocks__/db.ts` の `getAllFromIndex` / `transaction.index().getAll()` で multiEntry インデックス（配列フィールド）対応（`Array.isArray` + `includes` 判定）。clipStore.test.ts にタグフィルタ検証テスト追加。（2026-02-28）

--- a/src/store/__mocks__/db.ts
+++ b/src/store/__mocks__/db.ts
@@ -49,7 +49,9 @@ const mockDB = {
     const store = getStore(storeName);
     if (query !== undefined) {
       const filtered = [...store.values()].filter((v) => {
-        return (v as Record<string, unknown>)[indexName] === query;
+        const value = (v as Record<string, unknown>)[indexName];
+        // multiEntry インデックス対応: 配列フィールドの場合は includes で判定
+        return Array.isArray(value) ? value.includes(query) : value === query;
       });
       return Promise.resolve(filtered.map((v) => structuredClone(v)));
     }
@@ -85,7 +87,9 @@ const mockDB = {
               const queryValue = (typeof globalThis.IDBKeyRange !== 'undefined' && query instanceof IDBKeyRange)
                 ? (query as unknown as { _value: unknown })._value : query;
               const values = [...store.values()].filter((v) => {
-                return (v as Record<string, unknown>)[idxName] === queryValue;
+                const value = (v as Record<string, unknown>)[idxName];
+                // multiEntry インデックス対応: 配列フィールドの場合は includes で判定
+                return Array.isArray(value) ? value.includes(queryValue) : value === queryValue;
               });
               return Promise.resolve(values.map((v) => structuredClone(v)));
             },

--- a/src/store/clipStore.test.ts
+++ b/src/store/clipStore.test.ts
@@ -156,6 +156,27 @@ describe('listClips', () => {
     expect(all[1].title).toBe('A');
   });
 
+  it('タグフィルタで該当クリップのみ返す（multiEntry 対応）', async () => {
+    await saveClip({ url: 'https://a.com', title: 'A', content: 'A', tags: ['frontend', 'react'] });
+    await saveClip({ url: 'https://b.com', title: 'B', content: 'B', tags: ['backend', 'node'] });
+    await saveClip({ url: 'https://c.com', title: 'C', content: 'C', tags: ['frontend', 'vue'] });
+
+    // 'frontend' タグで検索 → A, C がヒット
+    const frontend = await listClips('frontend');
+    expect(frontend).toHaveLength(2);
+    expect(frontend.map((c) => c.title).sort()).toEqual(['A', 'C']);
+
+    // 'react' タグで検索 → A のみヒット
+    const react = await listClips('react');
+    expect(react).toHaveLength(1);
+    expect(react[0].title).toBe('A');
+
+    // 'backend' タグで検索 → B のみヒット（frontend タグのクリップは含まれない）
+    const backend = await listClips('backend');
+    expect(backend).toHaveLength(1);
+    expect(backend[0].title).toBe('B');
+  });
+
   it('limit で件数制限できる', async () => {
     for (let i = 0; i < 5; i++) {
       await saveClip({ url: `https://${i}.com`, title: `記事${i}`, content: `内容${i}` });


### PR DESCRIPTION
## Summary
- `src/store/__mocks__/db.ts` の `getAllFromIndex` と `transaction.index().getAll()` で、配列フィールド（multiEntry インデックス）の場合に `Array.isArray(value) ? value.includes(query) : value === query` で判定するように修正
- `clipStore.test.ts` に multiEntry タグフィルタの検証テストを追加（複数タグを持つクリップが各タグで正しくフィルタされることを確認）
- `docs/REVIEW-TRACKER.md` で「getAllFromIndex モックの正確性改善」を「将来対応」→「対応済み（PR-G）」に移動
- `docs/ROADMAP.md` に PR-G の完了記録を追加

## Test plan
- [x] `npm test` — 全 510 テスト通過
- [x] `npm run build` — ビルド成功
- [x] 新規テスト: 複数タグを持つクリップが各タグで検索できること
- [x] 新規テスト: タグ A でフィルタした結果にタグ B のみのクリップが含まれないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)