### PR TITLE
Declarative Web Push 検討結果を文書化

### DIFF
--- a/docs/NOTE-declarative-web-push-2026-03.md
+++ b/docs/NOTE-declarative-web-push-2026-03.md
@@ -1,0 +1,26 @@
+# Declarative Web Push 検討メモ（2026-03）
+
+## 結論
+- PoC 期間は Declarative Web Push へ移行せず、既存の Push（VAPID + `ServiceWorkerRegistration.pushManager`）と Periodic Background Sync フォールバックを継続する。
+
+## 調査サマリ
+- WebKit は Declarative Web Push を発表し、iOS/iPadOS 18.4 および macOS 18.5 で利用可能と記載している。
+- 仕様は W3C Push API の拡張提案（PR）として議論中で、標準の確定版には未反映。
+- MDN の現行 PushManager ガイドは、依然として Service Worker 登録経由（`ServiceWorkerRegistration.pushManager`）を前提に説明している。
+
+## iAgent への判断
+- 現行実装は `src/core/pushSubscription.ts` で `navigator.serviceWorker.ready` + `registration.pushManager` を中核にしており、既にブラウザ実装差を吸収した運用ができている。
+- Declarative Web Push を PoC 段階で導入すると、Safari 先行実装に依存した分岐実装と検証コストが増える。
+- サーバーレス化の可能性はあるが、現時点ではクロスブラウザの再現性を優先する。
+
+## 再検討トリガー
+- Chromium 系で Declarative Web Push が stable 提供され、主要 2 エンジン以上で同等機能が利用可能になった時点。
+- Push API 拡張が仕様として安定し、互換性リスクが下がった時点。
+
+## 参照
+- WebKit: Meet Declarative Web Push  
+  https://webkit.org/blog/16535/meet-declarative-web-push/
+- W3C Push API PR: Declarative Web Push Extensions  
+  https://github.com/w3c/push-api/pull/385
+- MDN: PushManager  
+  https://developer.mozilla.org/en-US/docs/Web/API/PushManager

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -154,7 +154,7 @@
 - [x] Periodic Background Sync の実際の最小間隔（12時間）に関するドキュメント・UI 説明追加
 - [x] iOS PWA インストール導線 — Safari は PWA インストール後のみ Push 対応、設定画面にガイド追加（フェーズ 3 スマートフォン対応強化で実装済み）
 - [x] Chrome 通知パーミッション自動取り消し対策 — 低エンゲージメントサイトで通知権限が自動取り消しされる問題への対応（定期的な権限チェック）
-- [ ] Declarative Web Push 対応検討 — Chrome 実装後のサーバーレス Push 通知（サーバー不要化の可能性）
+- [x] Declarative Web Push 対応検討 — 調査結果を [docs/NOTE-declarative-web-push-2026-03.md](NOTE-declarative-web-push-2026-03.md) に整理し、PoC では既存 Push + Periodic Sync 継続（再検討条件付き）で運用
 
 ---
 
@@ -361,3 +361,4 @@
 - [x] Heartbeat 条件付き実行（時間帯）— `HeartbeatTask.condition`（time-window）を追加し、`getTasksDue` / `getTasksDueFromIDB` で時間帯条件に合致するタスクのみ実行。`SettingsModal` のカスタムタスクに時間帯条件 UI（なし/時間帯指定）を追加し、`heartbeat.test.ts` / `heartbeatCommon.test.ts` / `config.test.ts` / `SettingsModal.test.tsx` を更新。（2026-03-06）
 - [x] 情報収集ワークフロー拡張（RSS ダイジェスト）— `rss-digest-daily` ビルトインタスクを追加（08:00 固定スケジュール）。`listClassifiedFeedItems` + `getCrossSourceTopics` を軸に日次要約し、分類済み記事がない場合は `listUnreadFeedItems` でヘッドライン要約にフォールバック。`heartbeatCost` で standard モデル実行に設定し、`config.test.ts` / `heartbeatCost.test.ts` を更新。（2026-03-06）
 - [x] ペルソナプリセット配布 + インポート（Phase D）— `core/personaPreset.ts` を追加し、`persona/suggestionFrequency/有効なビルトインタスク` の JSON プリセット生成・検証・適用を実装。`SettingsModal` のエージェント設定に `ペルソナプリセットをエクスポート` / `ペルソナプリセットをインポート` を追加。`readFileAsText`（`fileUtils`）を導入し、`File.text()` 非対応環境でもインポート可能化。`personaPreset.test.ts` / `SettingsModal.test.tsx` / `fileUtils.test.ts` を更新。（2026-03-06）
+- [x] Declarative Web Push 対応検討（PoC）— WebKit / W3C Push API 提案 / MDN 現行API を調査し、現時点では標準化・実装の過渡期と判断。iAgent は `ServiceWorkerRegistration.pushManager` ベースの既存 Push + Periodic Sync フォールバックを維持し、再検討条件（2エンジン以上の安定実装・仕様安定化）を文書化。（2026-03-06）


### PR DESCRIPTION
## 概要
- ROADMAP の未完了項目だった `Declarative Web Push 対応検討` を実施し、判断と再検討条件を文書化しました。

## 変更内容
- `docs/NOTE-declarative-web-push-2026-03.md` を追加
  - WebKit / W3C Push API PR / MDN を根拠に現時点の技術状況を整理
  - PoC では既存 Push + Periodic Sync 継続とする判断を記載
  - 再検討トリガー（2エンジン以上の安定実装・仕様安定化）を定義
- `docs/ROADMAP.md` の該当項目を完了化し、下部の進捗ログに追記

## 補足
- コード変更はありません（調査メモと計画整合のみ）。
