### PR TITLE
fix: validate imported backup attachments

### DIFF
--- a/src/core/dataPortability.test.ts
+++ b/src/core/dataPortability.test.ts
@@ -211,4 +211,25 @@ describe('dataPortability', () => {
     expect(result.counts.archivedMemories).toBe(0);
     expect(result.counts.attachments).toBe(0);
   });
+
+  it('importDataPortabilityFromJson は mimeType と dataUri の不整合を拒否する', async () => {
+    const payload = {
+      format: DATA_PORTABILITY_FORMAT,
+      schemaVersion: DATA_PORTABILITY_SCHEMA_VERSION,
+      exportedAt: 1_700_000_000_000,
+      config: makeConfig(),
+      conversationMeta: [makeConversation('conv-1', 1)],
+      conversations: [makeMessage('msg-1', 2, 'conv-1')],
+      memories: [makeMemory('mem-1', 3)],
+      attachments: [
+        {
+          ...makeAttachment('att-1', 4, 'msg-1', 'conv-1'),
+          mimeType: 'image/png',
+          dataUri: 'data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=',
+        },
+      ],
+    };
+
+    await expect(importDataPortabilityFromJson(JSON.stringify(payload))).rejects.toThrow();
+  });
 });

--- a/src/core/dataPortability.ts
+++ b/src/core/dataPortability.ts
@@ -5,6 +5,7 @@ import { saveConfigToIDB } from '../store/configStore';
 import { normalizeStoredAttachment, toStoredAttachmentRow, type StoredAttachmentRow } from '../store/attachmentStore';
 import type { AppConfig, ChatMessage, Conversation, Memory, ArchivedMemory } from '../types';
 import type { Attachment } from '../types/attachment';
+import { ALLOWED_MIME_TYPES, MAX_FILE_SIZE, SUPPORTED_IMAGE_TYPES } from '../types/attachment';
 
 export const DATA_PORTABILITY_FORMAT = 'iagent-data-export';
 export const DATA_PORTABILITY_SCHEMA_VERSION = 1 as const;
@@ -70,6 +71,11 @@ const archivedMemorySchema = baseMemorySchema.extend({
   archiveReason: z.enum(['low-score', 'manual', 'consolidation']).optional().default('low-score'),
 }).passthrough();
 
+function extractDataUriMimeType(dataUri: string): string | null {
+  const match = dataUri.match(/^data:([^;,]+)(?:;[^,]*)?,/);
+  return match?.[1] ?? null;
+}
+
 const attachmentSchema = z.object({
   id: z.string(),
   messageId: z.string(),
@@ -80,7 +86,43 @@ const attachmentSchema = z.object({
   dataUri: z.string(),
   thumbnailUri: z.string().optional(),
   createdAt: z.number().finite(),
-}).passthrough();
+}).passthrough().superRefine((attachment, ctx) => {
+  if (!ALLOWED_MIME_TYPES.includes(attachment.mimeType)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['mimeType'],
+      message: `Unsupported MIME type: ${attachment.mimeType}`,
+    });
+  }
+
+  if (attachment.size === 0 || attachment.size > MAX_FILE_SIZE) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['size'],
+      message: `Attachment size must be 1-${MAX_FILE_SIZE} bytes`,
+    });
+  }
+
+  const dataUriMimeType = extractDataUriMimeType(attachment.dataUri);
+  if (dataUriMimeType !== attachment.mimeType) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['dataUri'],
+      message: 'dataUri MIME type must match attachment mimeType',
+    });
+  }
+
+  if (attachment.thumbnailUri) {
+    const thumbnailMimeType = extractDataUriMimeType(attachment.thumbnailUri);
+    if (!thumbnailMimeType || !SUPPORTED_IMAGE_TYPES.includes(thumbnailMimeType)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['thumbnailUri'],
+        message: 'thumbnailUri must be a supported image data URI',
+      });
+    }
+  }
+});
 
 const taskScheduleSchema = z.object({
   type: z.enum(['global', 'interval', 'fixed-time']),


### PR DESCRIPTION
### Motivation
- バックアップのインポート経路が添付ファイルの MIME / サイズ / data URI を検証せずに永続化しており、悪意ある backup による stored XSS を許していたため修正する。 
- 既存の通常アップロード経路では MIME ホワイトリストやサイズチェックがあるが、インポートはそれをバイパスしていた。 

### Description
- `src/core/dataPortability.ts` の添付スキーマにインポート時検証を追加し、許可された MIME のみ許可するようにした（`ALLOWED_MIME_TYPES` を利用）。
- 添付のサイズを `1..MAX_FILE_SIZE` 範囲に制限し、`dataUri` 内の MIME と `mimeType` が一致することを強制するチェックを追加した。 
- `thumbnailUri` が存在する場合はサポート済み画像 MIME（`SUPPORTED_IMAGE_TYPES`）の data URI であることを検証するためのヘルパー `extractDataUriMimeType` を追加した。 
- 回帰テストを `src/core/dataPortability.test.ts` に追加し、`mimeType` と `dataUri` が不整合な場合にインポートを拒否することを確認するテストを追加した。 

### Testing
- 変更対象テストを実行して検証し、`npm test -- --run src/core/dataPortability.test.ts` の結果は全て成功（`7 passed`）。
- 自動テストは `src/core/dataPortability.test.ts` を追加/修正した回帰テストを含む。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab8a90e2708321959b4d710404ad26)